### PR TITLE
Fix zero roughness length using DEPHY format with non-LSM ICs

### DIFF
--- a/scm/src/gmtb_scm_type_defs.F90
+++ b/scm/src/gmtb_scm_type_defs.F90
@@ -1357,19 +1357,19 @@ module gmtb_scm_type_defs
         end if
       end if
       
-      if (scm_input%input_tsfcl < real_zero) then
+      if (scm_input%input_tsfcl <= real_zero) then
         physics%Sfcprop%tsfcl(i) = physics%Sfcprop%tsfco(i) !--- compute tsfcl from existing variables
       end if
       
-      if (scm_input%input_zorll < real_zero) then
+      if (scm_input%input_zorll <= real_zero) then
         physics%Sfcprop%zorll(i) = physics%Sfcprop%zorlo(i) !--- compute zorll from existing variables
       end if
       
-      if (scm_input%input_zorli < real_zero) then
+      if (scm_input%input_zorli <= real_zero) then
         physics%Sfcprop%zorli(i) = physics%Sfcprop%zorlo(i) !--- compute zorli from existing variables
       end if
       
-      if (scm_input%input_zorlw < real_zero) then
+      if (scm_input%input_zorlw <= real_zero) then
         physics%Sfcprop%zorlw(i) = physics%Sfcprop%zorlo(i) !--- compute zorlw from existing variables
       end if
       


### PR DESCRIPTION

Problem: For cases in the DEPHY format, the roughness length was not being properly initialized from the data file. It was read in properly, but in the case where the case data file does not contain model or LSM initial conditions, the values of the fractional landmask roughness length values (zorll, zorli, zorlw) were not being set from the one that is read in (zorlo). The logic assumed that input_zorl[l,i,w] would be set to a missing value (negative), but that does not happen in the read routine for the DEPHY format.

Solution: Modify the logic to set zorl[l,i,w] from zorlo if the input values are negative (missing) or zero (set to their initialization values).

Fixes #228