### PR TITLE
Feature/add timing  Add release branch timing information to SCM regression test output.

### DIFF
--- a/scm/src/multi_run_scm.py
+++ b/scm/src/multi_run_scm.py
@@ -57,7 +57,7 @@ def spawn_subprocess(command, timer):
         t = timeit.Timer(functools.partial(subprocess_work, command))
         #timer_iterations determines how many realizations are executed in order to calculate the elapsed time
         elapsed_time = t.timeit(timer_iterations)
-        logging.info('elapsed time: {0} s'.format(elapsed_time/timer_iterations))
+        return elapsed_time
     else:
         subprocess_work(command)
 
@@ -99,7 +99,10 @@ def main():
             if args.runtime:
                 command = command + ' --runtime ' + args.runtime
             logging.info('Executing process {0} of {1} ({2})'.format(i, len(suites), command))
-            spawn_subprocess(command, args.timer)
+            elapsed_time = spawn_subprocess(command, args.timer)
+            if args.timer:
+               logging.info('elapsed time: {0} s for case: {1} suite: {2}'\
+                  .format(elapsed_time/timer_iterations, args.case, suite))
 
     # if the suite argument is specified, run through all supported cases with the specified suite
     if args.suite:
@@ -111,7 +114,10 @@ def main():
             if args.runtime:
                 command = command + ' --runtime ' + args.runtime
             logging.info('Executing process {0} of {1} ({2})'.format(i, len(cases), command))
-            spawn_subprocess(command, args.timer)
+            elapsed_time = spawn_subprocess(command, args.timer)
+            if args.timer:
+              logging.info('elapsed time: {0} s for case: {1} suite: {2}'\
+                 .format(elapsed_time/timer_iterations, case, args.suite))
 
     # For maximum flexibility, run the SCM as specified from an external file where cases, suites, and physics namelists
     # are all specified. This file must contain python lists called 'cases','suites', and 'namelists'. The suites and
@@ -156,7 +162,10 @@ def main():
                 if args.runtime:
                     command = command + ' --runtime ' + args.runtime
                 logging.info('Executing process {0} of {1} ({2})'.format(i, len(scm_runs.cases), command))
-                spawn_subprocess(command, args.timer)
+                elapsed_time = spawn_subprocess(command, args.timer)
+                if args.timer:
+                   logging.info('elapsed time: {0} s for case: {1} suite: {2}'\
+                      .format(elapsed_time/timer_iterations, case, args.file))
 
         if scm_runs.cases and scm_runs.suites:
             if scm_runs.namelists:
@@ -172,7 +181,10 @@ def main():
                                 command = command + ' --runtime ' + args.runtime
                             logging.info('Executing process {0} of {1} ({2})'.format(
                                 len(scm_runs.namelists)*i+j, len(scm_runs.cases)*len(scm_runs.namelists), command))
-                            spawn_subprocess(command, args.timer)
+                            elapsed_time = spawn_subprocess(command, args.timer)
+                            if args.timer:
+                               logging.info('elapsed time: {0} s for case: {1} suite: {2}'\
+                                  .format(elapsed_time/timer_iterations, case, scm_runs.suites[0]))
                 elif len(scm_runs.suites) == len(scm_runs.namelists):
                     logging.info('Cases, suites, and namelists were specified in {0}, so running all cases with all '\
                         'suites, matched with namelists by order'.format(args.file))
@@ -185,7 +197,10 @@ def main():
                                 command = command + ' --runtime ' + args.runtime
                             logging.info('Executing process {0} of {1} ({2})'.format(
                                 len(scm_runs.suites)*i+j, len(scm_runs.cases)*len(scm_runs.suites), command))
-                            spawn_subprocess(command, args.timer)
+                            elapsed_time = spawn_subprocess(command, args.timer)
+                            if args.timer:
+                               logging.info('elapsed time: {0} s for case: {1} suite: {2}'\
+                                  .format(elapsed_time/timer_iterations, case, suite))
                 else:
                     message = 'The number of suites and namelists specified in {0} is incompatible. Either use one '\
                         'suite with many namelists or the number of suites must match the number of namelists '\
@@ -204,7 +219,10 @@ def main():
                             command = command + ' --runtime ' + args.runtime
                         logging.info('Executing process {0} of {1} ({2})'.format(
                             len(scm_runs.suites)*i+j, len(scm_runs.cases)*len(scm_runs.suites), command))
-                        spawn_subprocess(command, args.timer)
+                        elapsed_time = spawn_subprocess(command, args.timer)
+                        if args.timer:
+                           logging.info('elapsed time: {0} s for case: {1} suite: {2}'\
+                              .format(elapsed_time/timer_iterations, case, suite))
 
         if scm_runs.cases and not scm_runs.suites and scm_runs.namelists:
             logging.info('Cases and namelists were specified in {0}, so running all cases with the default suite '\
@@ -218,7 +236,10 @@ def main():
                         command = command + ' --runtime ' + args.runtime
                     logging.info('Executing process {0} of {1} ({2})'.format(
                         len(scm_runs.namelists)*i+j, len(scm_runs.cases)*len(scm_runs.namelists), command))
-                    spawn_subprocess(command, args.timer)
+                    elapsed_time = spawn_subprocess(command, args.timer)
+                    if args.timer:
+                      logging.info('elapsed time: {0} s for case: {1} namelist: {2}'\
+                         .format(elapsed_time/timer_iterations, case, namelist))
 
     # If running the script with no arguments, run all supported (case,suite) permutations.
     if not args.case and not args.suite and not args.file:
@@ -233,7 +254,10 @@ def main():
                     command = command + ' --runtime ' + args.runtime
                 logging.info('Executing process {0} of {1} ({2})'.format(
                     len(suites)*i+j, len(cases)*len(suites), command))
-                spawn_subprocess(command, args.timer)
+                elapsed_time = spawn_subprocess(command, args.timer)
+                if args.timer:
+                   logging.info('elapsed time: {0} s for case: {1} suite: {2}'\
+                      .format(elapsed_time/timer_iterations, case, suite))
 
     # Generate report at the end of the log file when verbose flag is set
     if args.verbose > 0:

--- a/test/rt.sh
+++ b/test/rt.sh
@@ -231,7 +231,7 @@ for compiler in "${compilers[@]}"; do
       # Add --runtime ${runtime} to multi_run_scm.py to reduce runtime for tests
       test_run_cmd="${RUN_DIR}/multi_run_scm.py -f ${TEST_DIR}/rt_test_cases.py -v --runtime 86400" # 1 day
     else
-      test_run_cmd="${RUN_DIR}/multi_run_scm.py -f ${TEST_DIR}/rt_test_cases.py -v --runtime 259200" # 3 days
+      test_run_cmd="${RUN_DIR}/multi_run_scm.py -f ${TEST_DIR}/rt_test_cases.py -v --timer --runtime 259200" # 3 days
     fi
 
     . ${ETC_DIR}/${machine}_setup_${compiler}.sh
@@ -353,6 +353,7 @@ n_completed=$(grep -c "PASS: All processes completed successfully" ${TEST_OUTPUT
 
 if [[ $n_completed -eq $n_tests && $n_fail -eq 0 && $n_error -eq 0 ]] ; then
   echo "ALL TESTS SUCCEEDED" >> ${TEST_OUTPUT}
+  msg="PASS"
 #-----------------------------------------------------------------------
 # Generate baseline if option is set
 #-----------------------------------------------------------------------

--- a/test/summarize.sh
+++ b/test/summarize.sh
@@ -74,6 +74,16 @@ else
   echo "FAIL: Number output.nc files ${num_output_nc_files} /= ${num_tests}" >> ${TEST_OUTPUT}
 fi
 
+#-----------------------------------------------------------------------
+# Get timing information
+#-----------------------------------------------------------------------
+echo " " >> ${TEST_OUTPUT}
+if grep -q "elapsed" ${file}; then
+  echo "Timing Information:" >> ${TEST_OUTPUT}
+  echo "===================" >> ${TEST_OUTPUT}
+  grep "elapsed" ${file} >> ${TEST_OUTPUT}
+fi
+
 echo " " >> ${TEST_OUTPUT}
 echo "Process details:" >> ${TEST_OUTPUT}
 echo "================" >> ${TEST_OUTPUT}


### PR DESCRIPTION
- Add ``--timer`` option to call to ``multi_run_scm.py`` in ``rt.sh``.  The execution time includes file
  operations performed by the single run script in addition to the execution of the SCM executable.
  By default, this option will execute one integration of each subprocess.
- Modify ``spawn_process`` in ``multi_run_scm.py`` to return ``elapsed_time`` and do the ``logging.info()``
  call in the main subroutine to allow output of case and suite name with elapsed time
- Add grep for elapsed time in output file

All tests pass on Cheyenne, Hera and MacOS.

Sample output from Cheyenne, Intel Release, 3 day run time:

Timing Information:
===================
INFO: elapsed time: 29.44097218999741 s for case: arm_sgp_summer_1997_A suite: SCM_GFS_v15p2
INFO: elapsed time: 29.78753030200096 s for case: arm_sgp_summer_1997_A suite: SCM_GFS_v16
INFO: elapsed time: 28.463698947998637 s for case: arm_sgp_summer_1997_A suite: SCM_csawmg
INFO: elapsed time: 26.47791115900327 s for case: arm_sgp_summer_1997_A suite: SCM_GSD_v1
INFO: elapsed time: 29.508932278997236 s for case: arm_sgp_summer_1997_A suite: SCM_RRFS_v1alpha
INFO: elapsed time: 31.379314743997384 s for case: astex suite: SCM_GFS_v15p2
INFO: elapsed time: 29.16681917999813 s for case: astex suite: SCM_GFS_v16
INFO: elapsed time: 28.156660523000028 s for case: astex suite: SCM_csawmg
INFO: elapsed time: 30.249316837998776 s for case: astex suite: SCM_GSD_v1
INFO: elapsed time: 33.81716114500159 s for case: astex suite: SCM_RRFS_v1alpha
INFO: elapsed time: 29.730581029998575 s for case: bomex suite: SCM_GFS_v15p2
INFO: elapsed time: 33.542763142002514 s for case: bomex suite: SCM_GFS_v16
INFO: elapsed time: 13.405209975000616 s for case: bomex suite: SCM_csawmg
INFO: elapsed time: 12.469535121999797 s for case: bomex suite: SCM_GSD_v1
INFO: elapsed time: 14.019247991000157 s for case: bomex suite: SCM_RRFS_v1alpha
INFO: elapsed time: 9.105098789001204 s for case: LASSO_2016051812 suite: SCM_GFS_v15p2
INFO: elapsed time: 11.402479061998747 s for case: LASSO_2016051812 suite: SCM_GFS_v16
INFO: elapsed time: 12.84378830499918 s for case: LASSO_2016051812 suite: SCM_csawmg
INFO: elapsed time: 11.545937935999973 s for case: LASSO_2016051812 suite: SCM_GSD_v1
INFO: elapsed time: 13.280678438000905 s for case: LASSO_2016051812 suite: SCM_RRFS_v1alpha
INFO: elapsed time: 4.16155103300116 s for case: twpice suite: SCM_GFS_v15p2
INFO: elapsed time: 4.140975923000951 s for case: twpice suite: SCM_GFS_v16
INFO: elapsed time: 4.717112908998388 s for case: twpice suite: SCM_csawmg
INFO: elapsed time: 4.615590396999323 s for case: twpice suite: SCM_GSD_v1
INFO: elapsed time: 4.668886461997317 s for case: twpice suite: SCM_RRFS_v1alpha
