### PR TITLE
 Change netcdf definition of init_year etc. from float to integer

### DIFF
--- a/scm/src/scm_output.F90
+++ b/scm/src/scm_output.F90
@@ -110,11 +110,11 @@ subroutine output_init(scm_state, physics)
   CALL output_init_radtend(ncid, time_swrad_id, time_lwrad_id, hor_dim_id, vert_dim_id)
   CALL output_init_diag(ncid, time_inst_id, time_diag_id, time_rad_id, hor_dim_id, vert_dim_id, physics)
   
-  call NetCDF_def_var(ncid, 'init_year',   NF90_FLOAT, "model initialization year",   "year",   year_id)
-  call NetCDF_def_var(ncid, 'init_month',  NF90_FLOAT, "model initialization month",  "month",  month_id)
-  call NetCDF_def_var(ncid, 'init_day',    NF90_FLOAT, "model initialization day",    "day",    day_id)
-  call NetCDF_def_var(ncid, 'init_hour',   NF90_FLOAT, "model initialization hour",   "hour",   hour_id)
-  call NetCDF_def_var(ncid, 'init_minute', NF90_FLOAT, "model initialization minute", "minute", min_id)
+  call NetCDF_def_var(ncid, 'init_year',   NF90_INT, "model initialization year",   "year",   year_id)
+  call NetCDF_def_var(ncid, 'init_month',  NF90_INT, "model initialization month",  "month",  month_id)
+  call NetCDF_def_var(ncid, 'init_day',    NF90_INT, "model initialization day",    "day",    day_id)
+  call NetCDF_def_var(ncid, 'init_hour',   NF90_INT, "model initialization hour",   "hour",   hour_id)
+  call NetCDF_def_var(ncid, 'init_minute', NF90_INT, "model initialization minute", "minute", min_id)
   
   !> - Close variable definition and the file.
   CALL CHECK(NF90_ENDDEF(NCID=ncid))

--- a/scm/src/scm_utils.F90
+++ b/scm/src/scm_utils.F90
@@ -666,7 +666,12 @@ module NetCDF_def
     end if
     CALL CHECK(NF90_PUT_ATT(NCID=ncid,VARID=varid,NAME="description",VALUES=desc))
     CALL CHECK(NF90_PUT_ATT(NCID=ncid,VARID=varid,NAME="units",VALUES=unit))
+!    CALL CHECK(NF90_PUT_ATT(NCID=ncid,VARID=varid,NAME="_FillValue",VALUES=missing_value))
+    IF ( var_type /= NF90_INT ) THEN
     CALL CHECK(NF90_PUT_ATT(NCID=ncid,VARID=varid,NAME="_FillValue",VALUES=missing_value))
+    ELSE
+    CALL CHECK(NF90_PUT_ATT(NCID=ncid,VARID=varid,NAME="_FillValue",VALUES=NF90_FILL_INT))
+    ENDIF
   
   end subroutine NetCDF_def_var
 end module NetCDF_def


### PR DESCRIPTION
The python program scm_analysis.py fails on the datetime.datetime function because it expects init_year, init_month etc. to be integers. Since these variables are declared as integers in the SCM code, this PR changes the netcdf output of the init_year, etc. from float to integer. The python read then recognizes the variables as integers and runs correctly.

An alternate temporay solution is to convert to integer in the script, e.g.,

from
year.append(nc_fid.variables['init_year'][:])
to
year.append(int(nc_fid.variables['init_year'][:]))

