### PR TITLE
Fix output-related bugs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # These owners will be the default owners for everything in the repo.
 #*       @defunkt
-*       @climbfuji @grantfirl
+*       @climbfuji @grantfirl @mkavulich
 
 # Order is important. The last matching pattern has the most precedence.
 # So if a pull request only touches javascript files, only these owners

--- a/scm/etc/scripts/plot_configs/all_vars_test_twpice.ini
+++ b/scm/etc/scripts/plot_configs/all_vars_test_twpice.ini
@@ -41,8 +41,8 @@ time_series_resample = True
       vars_labels = 'updraft mass flux','downdraft mass flux','detrainment mass flux'
       x_label = '$kg$ $m^{-2}$ $s^{-1}$'
     [[[T_tendencies]]]
-      vars = T_force_tend, dT_dt_pbl, dT_dt_deepconv, dT_dt_shalconv, dT_dt_micro, dT_dt_lwrad, dT_dt_swrad, dT_dt_ogwd, dT_dt_rayleigh, dT_dt_cgwd
-      vars_labels = 'force', 'PBL', 'Deep Con', 'Shal Con', 'MP', 'LW', 'SW', 'OGWD', 'Rayleigh', 'CGWD'
+      vars = T_force_tend, dT_dt_pbl, dT_dt_deepconv, dT_dt_shalconv, dT_dt_micro, dT_dt_lwrad, dT_dt_swrad, dT_dt_ogwd, dT_dt_cgwd
+      vars_labels = 'force', 'PBL', 'Deep Con', 'Shal Con', 'MP', 'LW', 'SW', 'OGWD', 'CGWD'
       x_label = '$K$ $day^{-1}$'
       conversion_factor = 8.64E4
     [[[T_force_phys]]]
@@ -66,8 +66,8 @@ time_series_resample = True
       x_label = '$g$ $kg^{-1}$ $day^{-1}$'
       conversion_factor = 8.64E7
     [[[u_tendencies]]]
-      vars = du_dt_pbl, du_dt_ogwd, du_dt_deepconv, du_dt_shalconv, du_dt_cgwd, du_dt_rayleigh
-      vars_labels = 'PBL', 'OGWD', 'Deep Con', 'Shal Con', 'CGWD', 'Rayleigh'
+      vars = du_dt_pbl, du_dt_ogwd, du_dt_deepconv, du_dt_shalconv, du_dt_cgwd
+      vars_labels = 'PBL', 'OGWD', 'Deep Con', 'Shal Con', 'CGWD'
       x_label = '$m$ $s^{-1}$ $day^{-1}$'
       conversion_factor = 8.64E4
     [[[u_force_phys]]]
@@ -76,8 +76,8 @@ time_series_resample = True
       x_label = '$m$ $s^{-1}$ $day^{-1}$'
       conversion_factor = 8.64E4
     [[[v_tendencies]]]
-      vars = dv_dt_pbl, dv_dt_ogwd, dv_dt_deepconv, dv_dt_shalconv, dv_dt_cgwd, dv_dt_rayleigh
-      vars_labels = 'PBL', 'OGWD', 'Deep Con', 'Shal Con', 'CGWD', 'Rayleigh'
+      vars = dv_dt_pbl, dv_dt_ogwd, dv_dt_deepconv, dv_dt_shalconv, dv_dt_cgwd
+      vars_labels = 'PBL', 'OGWD', 'Deep Con', 'Shal Con', 'CGWD'
       x_label = '$m$ $s^{-1}$ $day^{-1}$'
       conversion_factor = 8.64E4
     [[[v_force_phys]]]

--- a/scm/etc/scripts/scm_analysis.py
+++ b/scm/etc/scripts/scm_analysis.py
@@ -42,6 +42,13 @@ except (AttributeError):
 def print_progress(n_complete, n_total):
     print(str(n_complete) + ' of ' + str(n_total) + ' complete: (' + str(100.0*n_complete/float(n_total)) + '%)')
 
+def replace_fill_with_nan(nc_ds, var_name, var, group):
+    raw_data = nc_ds.variables[var_name][:]
+    raw_data[raw_data == nc_fid.variables[var_name]._FillValue] = np.nan
+    var.append(raw_data)
+    group.append(var_name)
+    return [var, group]
+
 #set up command line argument parser to read in name of config file to use
 parser = argparse.ArgumentParser()
 parser.add_argument('config', help='configuration file for CCPP SCM analysis', nargs=1)
@@ -123,8 +130,6 @@ for filename in glob.glob(os.path.join(dir, '*.nml')):
     nml = f90nml.read(filename)
     if nml['case_config']:
         case_name = nml['case_config']['case_name']
-
-
 
 #initialize lists for output variables
 year = []
@@ -574,137 +579,97 @@ for i in range(len(scm_datasets)):
     hpbl.append(nc_fid.variables['hpbl'][:])
     inst_time_group.append('hpbl')
     
-    dT_dt_lwrad.append(nc_fid.variables['dT_dt_lwrad'][:])
-    diag_time_group.append('dT_dt_lwrad')
+    [dT_dt_lwrad, diag_time_group] = replace_fill_with_nan(nc_fid, 'dT_dt_lwrad', dT_dt_lwrad, diag_time_group)
     
-    dT_dt_swrad.append(nc_fid.variables['dT_dt_swrad'][:])
-    diag_time_group.append('dT_dt_swrad')
+    [dT_dt_swrad, diag_time_group] = replace_fill_with_nan(nc_fid, 'dT_dt_swrad', dT_dt_swrad, diag_time_group)    
     
-    dT_dt_pbl.append(nc_fid.variables['dT_dt_pbl'][:])
-    diag_time_group.append('dT_dt_pbl')
+    [dT_dt_pbl, diag_time_group] = replace_fill_with_nan(nc_fid, 'dT_dt_pbl', dT_dt_pbl, diag_time_group)    
     
-    dT_dt_deepconv.append(nc_fid.variables['dT_dt_deepconv'][:])
-    diag_time_group.append('dT_dt_deepconv')
+    [dT_dt_deepconv, diag_time_group] = replace_fill_with_nan(nc_fid, 'dT_dt_deepconv', dT_dt_deepconv, diag_time_group)    
     
-    dT_dt_shalconv.append(nc_fid.variables['dT_dt_shalconv'][:])
-    diag_time_group.append('dT_dt_shalconv')
+    [dT_dt_shalconv, diag_time_group] = replace_fill_with_nan(nc_fid, 'dT_dt_shalconv', dT_dt_shalconv, diag_time_group)    
     
-    dT_dt_micro.append(nc_fid.variables['dT_dt_micro'][:])
-    diag_time_group.append('dT_dt_micro')
+    [dT_dt_micro, diag_time_group] = replace_fill_with_nan(nc_fid, 'dT_dt_micro', dT_dt_micro, diag_time_group)
     
     dT_dt_conv.append(dT_dt_deepconv[-1] + dT_dt_shalconv[-1])
     diag_time_group.append('dT_dt_conv')
     
-    dT_dt_ogwd.append(nc_fid.variables['dT_dt_ogwd'][:])
-    diag_time_group.append('dT_dt_ogwd')
+    [dT_dt_ogwd, diag_time_group] = replace_fill_with_nan(nc_fid, 'dT_dt_ogwd', dT_dt_ogwd, diag_time_group)
     
-    dT_dt_rayleigh.append(nc_fid.variables['dT_dt_rayleigh'][:])
-    diag_time_group.append('dT_dt_rayleigh')
+    [dT_dt_rayleigh, diag_time_group] = replace_fill_with_nan(nc_fid, 'dT_dt_rayleigh', dT_dt_rayleigh, diag_time_group)    
     
-    dT_dt_cgwd.append(nc_fid.variables['dT_dt_cgwd'][:])
-    diag_time_group.append('dT_dt_cgwd')
+    [dT_dt_cgwd, diag_time_group] = replace_fill_with_nan(nc_fid, 'dT_dt_cgwd', dT_dt_cgwd, diag_time_group)    
     
-    dT_dt_phys.append(nc_fid.variables['dT_dt_phys'][:])
-    diag_time_group.append('dT_dt_phys')
+    [dT_dt_phys, diag_time_group] = replace_fill_with_nan(nc_fid, 'dT_dt_phys', dT_dt_phys, diag_time_group)    
     
-    dT_dt_nonphys.append(nc_fid.variables['dT_dt_nonphys'][:])
-    diag_time_group.append('dT_dt_nonphys')
+    [dT_dt_nonphys, diag_time_group] = replace_fill_with_nan(nc_fid, 'dT_dt_nonphys', dT_dt_nonphys, diag_time_group)    
     
-    dq_dt_pbl.append(nc_fid.variables['dq_dt_pbl'][:])
-    diag_time_group.append('dq_dt_pbl')
+    [dq_dt_pbl, diag_time_group] = replace_fill_with_nan(nc_fid, 'dq_dt_pbl', dq_dt_pbl, diag_time_group)    
+        
+    [dq_dt_deepconv, diag_time_group] = replace_fill_with_nan(nc_fid, 'dq_dt_deepconv', dq_dt_deepconv, diag_time_group)
     
-    dq_dt_deepconv.append(nc_fid.variables['dq_dt_deepconv'][:])
-    diag_time_group.append('dq_dt_deepconv')
+    [dq_dt_shalconv, diag_time_group] = replace_fill_with_nan(nc_fid, 'dq_dt_shalconv', dq_dt_shalconv, diag_time_group)
     
-    dq_dt_shalconv.append(nc_fid.variables['dq_dt_shalconv'][:])
-    diag_time_group.append('dq_dt_shalconv')
-    
-    dq_dt_micro.append(nc_fid.variables['dq_dt_micro'][:])
-    diag_time_group.append('dq_dt_micro')
-    
+    [dq_dt_micro, diag_time_group] = replace_fill_with_nan(nc_fid, 'dq_dt_micro', dq_dt_micro, diag_time_group)    
+        
     dq_dt_conv.append(dq_dt_deepconv[-1] + dq_dt_shalconv[-1])
     diag_time_group.append('dq_dt_conv')
     
-    dq_dt_phys.append(nc_fid.variables['dq_dt_phys'][:])
-    diag_time_group.append('dq_dt_phys')
+    [dq_dt_phys, diag_time_group] = replace_fill_with_nan(nc_fid, 'dq_dt_phys', dq_dt_phys, diag_time_group)
     
-    dq_dt_nonphys.append(nc_fid.variables['dq_dt_nonphys'][:])
-    diag_time_group.append('dq_dt_nonphys')
+    [dq_dt_nonphys, diag_time_group] = replace_fill_with_nan(nc_fid, 'dq_dt_nonphys', dq_dt_nonphys, diag_time_group)    
     
-    doz_dt_pbl.append(nc_fid.variables['doz_dt_pbl'][:])
-    diag_time_group.append('doz_dt_pbl')
+    [doz_dt_pbl, diag_time_group] = replace_fill_with_nan(nc_fid, 'doz_dt_pbl', doz_dt_pbl, diag_time_group)    
     
-    doz_dt_prodloss.append(nc_fid.variables['doz_dt_prodloss'][:])
-    diag_time_group.append('doz_dt_prodloss')
+    [doz_dt_prodloss, diag_time_group] = replace_fill_with_nan(nc_fid, 'doz_dt_prodloss', doz_dt_prodloss, diag_time_group)    
     
-    doz_dt_oz.append(nc_fid.variables['doz_dt_oz'][:])
-    diag_time_group.append('doz_dt_oz')
+    [doz_dt_oz, diag_time_group] = replace_fill_with_nan(nc_fid, 'doz_dt_oz', doz_dt_oz, diag_time_group)    
     
-    doz_dt_T.append(nc_fid.variables['doz_dt_T'][:])
-    diag_time_group.append('doz_dt_T')
+    [doz_dt_T, diag_time_group] = replace_fill_with_nan(nc_fid, 'doz_dt_T', doz_dt_T, diag_time_group)    
     
-    doz_dt_ovhd.append(nc_fid.variables['doz_dt_ovhd'][:])
-    diag_time_group.append('doz_dt_ovhd')
+    [doz_dt_ovhd, diag_time_group] = replace_fill_with_nan(nc_fid, 'doz_dt_ovhd', doz_dt_ovhd, diag_time_group)    
     
-    doz_dt_phys.append(nc_fid.variables['doz_dt_phys'][:])
-    diag_time_group.append('doz_dt_phys')
+    [doz_dt_phys, diag_time_group] = replace_fill_with_nan(nc_fid, 'doz_dt_phys', doz_dt_phys, diag_time_group)
     
-    doz_dt_nonphys.append(nc_fid.variables['doz_dt_nonphys'][:])
-    diag_time_group.append('doz_dt_nonphys')
-        
-    du_dt_pbl.append(nc_fid.variables['du_dt_pbl'][:])
-    diag_time_group.append('du_dt_pbl')
+    [doz_dt_nonphys, diag_time_group] = replace_fill_with_nan(nc_fid, 'doz_dt_nonphys', doz_dt_nonphys, diag_time_group)    
     
-    du_dt_ogwd.append(nc_fid.variables['du_dt_ogwd'][:])
-    diag_time_group.append('du_dt_ogwd')
+    [du_dt_pbl, diag_time_group] = replace_fill_with_nan(nc_fid, 'du_dt_pbl', du_dt_pbl, diag_time_group)    
     
-    du_dt_deepconv.append(nc_fid.variables['du_dt_deepconv'][:])
-    diag_time_group.append('du_dt_deepconv')
+    [du_dt_ogwd, diag_time_group] = replace_fill_with_nan(nc_fid, 'du_dt_ogwd', du_dt_ogwd, diag_time_group)
     
-    du_dt_cgwd.append(nc_fid.variables['du_dt_cgwd'][:])
-    diag_time_group.append('du_dt_cgwd')
+    [du_dt_deepconv, diag_time_group] = replace_fill_with_nan(nc_fid, 'du_dt_deepconv', du_dt_deepconv, diag_time_group)
     
-    du_dt_rayleigh.append(nc_fid.variables['du_dt_rayleigh'][:])
-    diag_time_group.append('du_dt_rayleigh')
+    [du_dt_cgwd, diag_time_group] = replace_fill_with_nan(nc_fid, 'du_dt_cgwd', du_dt_cgwd, diag_time_group)
     
-    du_dt_shalconv.append(nc_fid.variables['du_dt_shalconv'][:])
-    diag_time_group.append('du_dt_shalconv')
+    [du_dt_rayleigh, diag_time_group] = replace_fill_with_nan(nc_fid, 'du_dt_rayleigh', du_dt_rayleigh, diag_time_group)
+    
+    [du_dt_shalconv, diag_time_group] = replace_fill_with_nan(nc_fid, 'du_dt_shalconv', du_dt_shalconv, diag_time_group)
     
     du_dt_conv.append(du_dt_deepconv[-1] + du_dt_shalconv[-1])
     diag_time_group.append('du_dt_conv')
     
-    du_dt_phys.append(nc_fid.variables['du_dt_phys'][:])
-    diag_time_group.append('du_dt_phys')
+    [du_dt_phys, diag_time_group] = replace_fill_with_nan(nc_fid, 'du_dt_phys', du_dt_phys, diag_time_group)
     
-    du_dt_nonphys.append(nc_fid.variables['du_dt_nonphys'][:])
-    diag_time_group.append('du_dt_nonphys')
+    [du_dt_nonphys, diag_time_group] = replace_fill_with_nan(nc_fid, 'du_dt_nonphys', du_dt_nonphys, diag_time_group)
+        
+    [dv_dt_pbl, diag_time_group] = replace_fill_with_nan(nc_fid, 'dv_dt_pbl', dv_dt_pbl, diag_time_group)    
     
-    dv_dt_pbl.append(nc_fid.variables['dv_dt_pbl'][:])
-    diag_time_group.append('dv_dt_pbl')
+    [dv_dt_ogwd, diag_time_group] = replace_fill_with_nan(nc_fid, 'dv_dt_ogwd', dv_dt_ogwd, diag_time_group)
     
-    dv_dt_ogwd.append(nc_fid.variables['dv_dt_ogwd'][:])
-    diag_time_group.append('dv_dt_ogwd')
+    [dv_dt_deepconv, diag_time_group] = replace_fill_with_nan(nc_fid, 'dv_dt_deepconv', dv_dt_deepconv, diag_time_group)
     
-    dv_dt_deepconv.append(nc_fid.variables['dv_dt_deepconv'][:])
-    diag_time_group.append('dv_dt_deepconv')
+    [dv_dt_cgwd, diag_time_group] = replace_fill_with_nan(nc_fid, 'dv_dt_cgwd', dv_dt_cgwd, diag_time_group)
     
-    dv_dt_cgwd.append(nc_fid.variables['dv_dt_cgwd'][:])
-    diag_time_group.append('dv_dt_cgwd')
+    [dv_dt_rayleigh, diag_time_group] = replace_fill_with_nan(nc_fid, 'dv_dt_rayleigh', dv_dt_rayleigh, diag_time_group)
     
-    dv_dt_rayleigh.append(nc_fid.variables['dv_dt_rayleigh'][:])
-    diag_time_group.append('dv_dt_rayleigh')
-    
-    dv_dt_shalconv.append(nc_fid.variables['dv_dt_shalconv'][:])
-    diag_time_group.append('dv_dt_shalconv')
+    [dv_dt_shalconv, diag_time_group] = replace_fill_with_nan(nc_fid, 'dv_dt_shalconv', dv_dt_shalconv, diag_time_group)
     
     dv_dt_conv.append(dv_dt_deepconv[-1] + dv_dt_shalconv[-1])
     diag_time_group.append('dv_dt_conv')
     
-    dv_dt_phys.append(nc_fid.variables['dv_dt_phys'][:])
-    diag_time_group.append('dv_dt_phys')
+    [dv_dt_phys, diag_time_group] = replace_fill_with_nan(nc_fid, 'dv_dt_phys', dv_dt_phys, diag_time_group)
     
-    dv_dt_nonphys.append(nc_fid.variables['dv_dt_nonphys'][:])
-    diag_time_group.append('dv_dt_nonphys')
+    [dv_dt_nonphys, diag_time_group] = replace_fill_with_nan(nc_fid, 'dv_dt_nonphys', dv_dt_nonphys, diag_time_group)
     
     tprcp_accum.append(nc_fid.variables['tprcp_accum'][:])
     diag_time_group.append('tprcp_accum')
@@ -785,7 +750,7 @@ for i in range(len(scm_datasets)):
     date_swrad.append(np.array([initial_date + datetime.timedelta(seconds=int(s)) for s in time_swrad[-1]]))
     date_lwrad.append(np.array([initial_date + datetime.timedelta(seconds=int(s)) for s in time_lwrad[-1]]))
     date_rad.append(np.array([initial_date + datetime.timedelta(seconds=int(s)) for s in time_rad[-1]]))
-
+        
     nc_fid.close()
 
     #calculate diagnostic values from model output
@@ -1026,7 +991,6 @@ if(plot_ind_datasets):
                                 data_time_slice = data[i,time_slice_indices_lwrad[j][0]:time_slice_indices_lwrad[j][1],:,:]
                             elif (profiles_mean_multi[multiplot]['vars'][l] in rad_time_group):
                                 #print("{} in time group rad".format(profiles_mean_multi[multiplot]['vars'][l]))
-                                print(profiles_mean_multi[multiplot]['vars'][l])
                                 data_time_slice = data[i,time_slice_indices_rad[j][0]:time_slice_indices_rad[j][1],:,:]
                             else:
                                 print("{} not found in any time groups".format(profiles_mean_multi[multiplot]['vars'][l]))

--- a/scm/etc/scripts/scm_analysis.py
+++ b/scm/etc/scripts/scm_analysis.py
@@ -750,7 +750,6 @@ for i in range(len(scm_datasets)):
     date_swrad.append(np.array([initial_date + datetime.timedelta(seconds=int(s)) for s in time_swrad[-1]]))
     date_lwrad.append(np.array([initial_date + datetime.timedelta(seconds=int(s)) for s in time_lwrad[-1]]))
     date_rad.append(np.array([initial_date + datetime.timedelta(seconds=int(s)) for s in time_rad[-1]]))
-        
     nc_fid.close()
 
     #calculate diagnostic values from model output

--- a/scm/src/scm.F90
+++ b/scm/src/scm.F90
@@ -209,8 +209,7 @@ subroutine scm_main_sub()
   physics%Model%first_time_step = .true.
 
   call output_init(scm_state, physics)
-  scm_state%itt_out = 1
-  call output_append(scm_state, physics)
+  call output_append(scm_state, physics, force=.true.)
 
   !first time step (call once)
 
@@ -358,7 +357,6 @@ subroutine scm_main_sub()
   end if
 
   if (.not. in_spinup) then
-    scm_state%itt_out = scm_state%itt_out + 1
     call output_append(scm_state, physics)
   end if
 
@@ -418,23 +416,17 @@ subroutine scm_main_sub()
       scm_state%state_tracer(:,:,scm_state%cloud_water_index,1) = scm_state%state_tracer(:,:,scm_state%cloud_water_index,2)
       scm_state%state_tracer(:,:,scm_state%ozone_index,1) = scm_state%state_tracer(:,:,scm_state%ozone_index,2)
     end if
-
-    if(mod(scm_state%itt, scm_state%n_itt_out)==0) then
-      
-      write(*,*) "itt = ",scm_state%itt
-      write(*,*) "model time (s) = ",scm_state%model_time
-      if (scm_state%lsm_ics .or. scm_state%model_ics) then
-        write(*,*) "Bowen ratio: ",physics%Interstitial%dtsfc1(1)/physics%Interstitial%dqsfc1(1)
-        write(*,*) "sensible heat flux (W m-2): ",physics%Interstitial%dtsfc1(1)
-        write(*,*) "latent heat flux (W m-2): ",physics%Interstitial%dqsfc1(1)
-      end if
-      write(*,*) "calling output routine..."
-      
-      if (.not. in_spinup) then
-        scm_state%itt_out = scm_state%itt_out+1
-        call output_append(scm_state, physics)
-      end if
-
+    
+    write(*,*) "itt = ",scm_state%itt
+    write(*,*) "model time (s) = ",scm_state%model_time
+    if (scm_state%lsm_ics .or. scm_state%model_ics) then
+      write(*,*) "Bowen ratio: ",physics%Interstitial%dtsfc1(1)/physics%Interstitial%dqsfc1(1)
+      write(*,*) "sensible heat flux (W m-2): ",physics%Interstitial%dtsfc1(1)
+      write(*,*) "latent heat flux (W m-2): ",physics%Interstitial%dqsfc1(1)
+    end if
+    
+    if (.not. in_spinup) then
+      call output_append(scm_state, physics)
     end if
   end do
 

--- a/scm/src/scm_output.F90
+++ b/scm/src/scm_output.F90
@@ -403,20 +403,28 @@ subroutine output_append(scm_state, physics, force)
   logical, optional, intent(in) :: force
   
   integer :: ncid, var_id
-
+  logical :: force_inst
+  
+  if (PRESENT(force)) then
+    force_inst = force
+  else
+    force_inst = .false.
+  end if
+  
   !> \section output_append_alg Algorithm
   !! @{
   if (.not. (mod(scm_state%itt, scm_state%n_itt_out)==0 .or. &
             physics%Model%lsswr .or. physics%Model%lslwr .or. &
             mod(scm_state%itt,physics%Model%nszero) == 0 .or. &
-            (PRESENT(force) .and. force))) then
+            force_inst)) then
     return
   end if
   !> - Open the file.
   CALL CHECK(NF90_OPEN(PATH=TRIM(scm_state%output_dir)//"/"//TRIM(scm_state%output_file)//".nc",MODE=NF90_WRITE,NCID=ncid))
   
   !> - Append all of the variables to the file.
-  if (mod(scm_state%itt, scm_state%n_itt_out)==0 .or. (PRESENT(force) .and. force)) then
+  
+  if (mod(scm_state%itt, scm_state%n_itt_out)==0 .or. force_inst) then
     scm_state%itt_out = scm_state%itt_out+1
     
     CALL CHECK(NF90_INQ_VARID(NCID=ncid,NAME="time_inst",VARID=var_id))

--- a/scm/src/scm_output.F90
+++ b/scm/src/scm_output.F90
@@ -392,35 +392,43 @@ subroutine output_init_diag(ncid, time_inst_id, time_diag_id, time_rad_id, hor_d
 end subroutine output_init_diag
 
 !> This subroutine appends data to the "output.nc" file.
-subroutine output_append(scm_state, physics)
+subroutine output_append(scm_state, physics, force)
 
   use scm_type_defs, only: scm_state_type, physics_type
 
   type(scm_state_type), intent(inout) :: scm_state
   type(physics_type), intent(in) :: physics
-
-  real(kind=dp), allocatable :: dummy_1D(:), dummy_2d(:,:)
+  logical, optional, intent(in) :: force
   
-  integer :: ncid, var_id, i, j
-  character(2) :: idx
-
-  allocate(dummy_1D(scm_state%n_cols), dummy_2d(scm_state%n_cols, scm_state%n_levels))
+  integer :: ncid, var_id
 
   !> \section output_append_alg Algorithm
   !! @{
-
+  if (.not. (mod(scm_state%itt, scm_state%n_itt_out)==0 .or. &
+            physics%Model%lsswr .or. physics%Model%lslwr .or. &
+            mod(scm_state%itt,physics%Model%nszero) == 0 .or. &
+            (PRESENT(force) .and. force))) then
+    return
+  end if
   !> - Open the file.
   CALL CHECK(NF90_OPEN(PATH=TRIM(scm_state%output_dir)//"/"//TRIM(scm_state%output_file)//".nc",MODE=NF90_WRITE,NCID=ncid))
   
   !> - Append all of the variables to the file.
-  CALL CHECK(NF90_INQ_VARID(NCID=ncid,NAME="time_inst",VARID=var_id))
-  CALL CHECK(NF90_PUT_VAR(NCID=ncid,VARID=var_id,VALUES=scm_state%model_time,START=(/ scm_state%itt_out /)))
+  if (mod(scm_state%itt, scm_state%n_itt_out)==0 .or. (PRESENT(force) .and. force)) then
+    scm_state%itt_out = scm_state%itt_out+1
+    
+    CALL CHECK(NF90_INQ_VARID(NCID=ncid,NAME="time_inst",VARID=var_id))
+    CALL CHECK(NF90_PUT_VAR(NCID=ncid,VARID=var_id,VALUES=scm_state%model_time,START=(/ scm_state%itt_out /)))
 
-  call output_append_state(ncid, scm_state, physics)
-  call output_append_forcing(ncid, scm_state)
+    call output_append_state(ncid, scm_state, physics)
+    call output_append_forcing(ncid, scm_state)
   
-  call output_append_sfcprop(ncid, scm_state, physics)
-  call output_append_interstitial_inst(ncid, scm_state, physics)
+    call output_append_sfcprop(ncid, scm_state, physics)
+    call output_append_interstitial_inst(ncid, scm_state, physics)
+    
+    call output_append_diag_inst(ncid, scm_state, physics)
+  end if
+  
   if(physics%Model%lslwr .or. physics%Model%lsswr) then
     if (physics%Model%lsswr) then
       scm_state%itt_swrad = scm_state%itt_swrad + 1
@@ -439,7 +447,7 @@ subroutine output_append(scm_state, physics)
     call output_append_interstitial_rad(ncid, scm_state, physics)
     call output_append_diag_rad(ncid, scm_state, physics)
   end if
-  call output_append_diag_inst(ncid, scm_state, physics)
+  
   if(mod(scm_state%itt,physics%Model%nszero) == 0) then
     scm_state%itt_diag = scm_state%itt_diag + 1
     CALL CHECK(NF90_INQ_VARID(NCID=ncid,NAME="time_diag",VARID=var_id))

--- a/scm/src/scm_output.F90
+++ b/scm/src/scm_output.F90
@@ -33,6 +33,7 @@ subroutine output_init(scm_state, physics)
   integer :: year_id, month_id, day_id, hour_id, min_id, time_swrad_var_id, time_lwrad_var_id, time_rad_var_id
   character(2) :: idx
   
+  real(kind=dp), dimension(scm_state%n_cols) :: missing_value_1D
   real(kind=dp), dimension(scm_state%n_cols,scm_state%n_levels) :: missing_value_2D
   
   !> \section output_init_alg Algorithm
@@ -141,6 +142,7 @@ subroutine output_init(scm_state, physics)
     !write out missing values at the initial time
     CALL CHECK(NF90_PUT_VAR(NCID=ncid,VARID=time_rad_var_id,VALUES=0.0,START=(/ 1 /)))
     missing_value_2D = missing_value
+    missing_value_1D = missing_value
     call NetCDF_put_var(ncid, "rad_cloud_fraction", missing_value_2D, 1)
     call NetCDF_put_var(ncid, "rad_cloud_lwp",      missing_value_2D, 1)
     call NetCDF_put_var(ncid, "rad_eff_rad_ql",     missing_value_2D, 1)
@@ -150,12 +152,12 @@ subroutine output_init(scm_state, physics)
     call NetCDF_put_var(ncid, "rad_eff_rad_qr",     missing_value_2D, 1)
     call NetCDF_put_var(ncid, "rad_cloud_swp",      missing_value_2D, 1)
     call NetCDF_put_var(ncid, "rad_eff_rad_qs",     missing_value_2D, 1)
-    call NetCDF_put_var(ncid, 'max_cloud_fraction', missing_value_2D, 1)
-    call NetCDF_put_var(ncid, 'toa_total_albedo',   missing_value_2D, 1)
-    call NetCDF_put_var(ncid, 'vert_int_lwp_mp',    missing_value_2D, 1)
-    call NetCDF_put_var(ncid, 'vert_int_iwp_mp',    missing_value_2D, 1)
-    call NetCDF_put_var(ncid, 'vert_int_lwp_cf',    missing_value_2D, 1)
-    call NetCDF_put_var(ncid, 'vert_int_iwp_cf',    missing_value_2D, 1)
+    call NetCDF_put_var(ncid, 'max_cloud_fraction', missing_value_1D, 1)
+    call NetCDF_put_var(ncid, 'toa_total_albedo',   missing_value_1D, 1)
+    call NetCDF_put_var(ncid, 'vert_int_lwp_mp',    missing_value_1D, 1)
+    call NetCDF_put_var(ncid, 'vert_int_iwp_mp',    missing_value_1D, 1)
+    call NetCDF_put_var(ncid, 'vert_int_lwp_cf',    missing_value_1D, 1)
+    call NetCDF_put_var(ncid, 'vert_int_iwp_cf',    missing_value_1D, 1)
   end if
   
   CALL CHECK(NF90_CLOSE(NCID=ncid))

--- a/scm/src/scm_utils.F90
+++ b/scm/src/scm_utils.F90
@@ -650,7 +650,7 @@ module NetCDF_def
   contains
   
   subroutine NetCDF_def_var(ncid, var_name, var_type, desc, unit, varid, dims)
-    use NetCDF_read, only: missing_value
+    use NetCDF_read, only: missing_value, missing_value_int
     integer, intent(in) :: ncid
     character (*), intent(in) :: var_name
     integer, intent(in) :: var_type
@@ -660,18 +660,21 @@ module NetCDF_def
     integer, intent(out) :: varid
     
     if (present(dims)) then
-      CALL CHECK(NF90_DEF_VAR(NCID=ncid,NAME=var_name,XTYPE=var_type,DIMIDS=dims,VARID=varid))
+      call CHECK(NF90_DEF_VAR(NCID=ncid,NAME=var_name,XTYPE=var_type,DIMIDS=dims,VARID=varid))
     else
-      CALL CHECK(NF90_DEF_VAR(NCID=ncid,NAME=var_name,XTYPE=var_type,VARID=varid))
+      call CHECK(NF90_DEF_VAR(NCID=ncid,NAME=var_name,XTYPE=var_type,VARID=varid))
     end if
-    CALL CHECK(NF90_PUT_ATT(NCID=ncid,VARID=varid,NAME="description",VALUES=desc))
-    CALL CHECK(NF90_PUT_ATT(NCID=ncid,VARID=varid,NAME="units",VALUES=unit))
-!    CALL CHECK(NF90_PUT_ATT(NCID=ncid,VARID=varid,NAME="_FillValue",VALUES=missing_value))
-    IF ( var_type /= NF90_INT ) THEN
-    CALL CHECK(NF90_PUT_ATT(NCID=ncid,VARID=varid,NAME="_FillValue",VALUES=missing_value))
-    ELSE
-    CALL CHECK(NF90_PUT_ATT(NCID=ncid,VARID=varid,NAME="_FillValue",VALUES=NF90_FILL_INT))
-    ENDIF
+    call CHECK(NF90_PUT_ATT(NCID=ncid,VARID=varid,NAME="description",VALUES=desc))
+    call CHECK(NF90_PUT_ATT(NCID=ncid,VARID=varid,NAME="units",VALUES=unit))
+    
+    if (var_type == NF90_FLOAT) then
+      call CHECK(NF90_PUT_ATT(NCID=ncid,VARID=varid,NAME="_FillValue",VALUES=missing_value))
+    elseif (var_type == NF90_INT) then
+      call CHECK(NF90_PUT_ATT(NCID=ncid,VARID=varid,NAME="_FillValue",VALUES=missing_value_int))
+    else
+      write(0,'(a,i0,a)') "The variable '" // var_name // "' is defined as a type other than NF90_FLOAT or NF90_INT. Stopping..."
+      STOP
+    end if
   
   end subroutine NetCDF_def_var
 end module NetCDF_def


### PR DESCRIPTION
- move increment of itt_out to output_append to be consistent with other output time indices
- add option to force writing instantaneous output (outside of normal cadence, e.g. initial conditions)
- call output_append at every timestep and return if no output should be written during current timestep
- fix bug when n_rad == 1 and/or when radiation is not called (missing value fills)
- fix type of initial date variables (thanks @MicroTed))
- write out appropriate missing value depending on output datatype in NetCDF_def_var (thanks @MicroTed)

This should cause failed SCM RTs due to changed output files.