### PR TITLE
update Hera setup scripts

### DIFF
--- a/scm/etc/Hera_setup_intel.csh
+++ b/scm/etc/Hera_setup_intel.csh
@@ -28,54 +28,6 @@ setenv CMAKE_CXX_COMPILER icpc
 setenv CMAKE_Fortran_COMPILER ifort
 setenv CMAKE_Platform hera.intel
 
-echo "Loading the anaconda python distribution"
-module use -a /contrib/anaconda/modulefiles
-module load anaconda/anaconda3-4.4.0
-
-#install f90nml for the local user
-
-#check to see if f90nml is installed locally
-echo "Checking if f90nml python module is installed"
-python -c "import f90nml"
-
-if ( $? != 0 ) then
-	echo "Not found; installing f90nml"
-	pip install -e git://github.com/marshallward/f90nml.git@v0.19\#egg=f90nml --user
-else
-	echo "f90nml is installed"
-endif
-
-#install shapely for the local user
-
-#check to see if shapely is installed locally
-echo "Checking if shapely python module is installed"
-python -c "import shapely"
-
-if ( $? != 0 ) then
-	echo "Not found; installing shapely"
-	pip install --index-url http://anaconda.rdhpcs.noaa.gov/simple --trusted-host anaconda.rdhpcs.noaa.gov shapely --user
-else
-	echo "shapely is installed"
-endif
-
-#check to see if configobj is installed locally
-echo "Checking if configobj python module is installed"
-python -c "import configobj"
-
-if ( $? != 0 ) then
-	echo "Not found; installing configobj"
-	pip install --index-url http://anaconda.rdhpcs.noaa.gov/simple --trusted-host anaconda.rdhpcs.noaa.gov configobj --user
-else
-	echo "configobj is installed"
-endif
-
-#check to see if netCDF4 is installed locally
-echo "Checking if netCDF4 python module is installed"
-python -c "import netCDF4"
-
-if ( $? != 0 ) then
-	echo "Not found; installing netCDF4"
-	pip install --index-url http://anaconda.rdhpcs.noaa.gov/simple --trusted-host anaconda.rdhpcs.noaa.gov netCDF4 --user
-else
-	echo "netCDF4 is installed"
-endif
+echo "Loading the SCM python environment"
+source /scratch1/BMC/gmtb/SCM_anaconda/etc/profile.d/conda.csh
+conda activate pyccpp

--- a/scm/etc/Hera_setup_intel.sh
+++ b/scm/etc/Hera_setup_intel.sh
@@ -25,54 +25,6 @@ export CMAKE_CXX_COMPILER=icpc
 export CMAKE_Fortran_COMPILER=ifort
 export CMAKE_Platform=hera.intel
 
-echo "Loading the anaconda python distribution"
-module use -a /contrib/anaconda/modulefiles
-module load anaconda/anaconda3-4.4.0
-
-#install f90nml for the local user
-
-#check to see if f90nml is installed locally
-echo "Checking if f90nml python module is installed"
-python -c "import f90nml"
-
-if [ $? -ne 0 ]; then
-	echo "Not found; installing f90nml"
-	pip install -e git://github.com/marshallward/f90nml.git@v0.19#egg=f90nml --user
-else
-	echo "f90nml is installed"
-fi
-
-#install shapely for the local user
-
-#check to see if shapely is installed locally
-echo "Checking if shapely python module is installed"
-python -c "import shapely"
-
-if [ $? -ne 0 ]; then
-	echo "Not found; installing shapely"
-	pip install --index-url http://anaconda.rdhpcs.noaa.gov/simple --trusted-host anaconda.rdhpcs.noaa.gov shapely --user
-else
-	echo "shapely is installed"
-fi
-
-#check to see if configobj is installed locally
-echo "Checking if configobj python module is installed"
-python -c "import configobj"
-
-if [ $? -ne 0 ]; then
-	echo "Not found; installing configobj"
-	pip install --index-url http://anaconda.rdhpcs.noaa.gov/simple --trusted-host anaconda.rdhpcs.noaa.gov configobj --user
-else
-	echo "configobj is installed"
-fi
-
-#check to see if netCDF4 is installed locally
-echo "Checking if netCDF4 python module is installed"
-python -c "import netCDF4"
-
-if [ $? -ne 0 ]; then
-	echo "Not found; installing netCDF4"
-	pip install --index-url http://anaconda.rdhpcs.noaa.gov/simple --trusted-host anaconda.rdhpcs.noaa.gov netCDF4 --user
-else
-	echo "netCDF4 is installed"
-fi
+echo "Loading the SCM python environment"
+. "/scratch1/BMC/gmtb/SCM_anaconda/etc/profile.d/conda.sh"
+conda activate pyccpp


### PR DESCRIPTION
Fixes https://github.com/NCAR/ccpp-scm/issues/298

Hera sysadmins changed how python is managed on Hera: https://rdhpcs-common-docs.rdhpcs.noaa.gov/wiki/index.php/Anaconda#Migrating_from_the_old_.22RDHPCS_mirror.22_installation_to_the_Anaconda_installation

Specifically, installing shapely, configobj, and netCDF4 using the method of grabbing the modules from the RDHPCS mirror does not work any more. According to their documentation, the preferred method for managing python is for users to install their own version of Miniconda and use that, which is what I did on Hera.

- I installed miniconda in /scratch1/BMC/gmtb/SCM_anaconda on Hera 
- create new "pyccpp" environment to maintain for CCPP SCM users (we can install whatever packages that we want in that environment in the future); this eliminates the need to check for installed packages and install them if missing -- if future users have a python package problem on Hera, it will be on SCM maintainers to update the pyccpp environment.

Note that UFS is going to use the hpc-stack repo for managing dependencies on supported platforms, which should also affect these files. I tried to follow their instructions for using hpc-stack modules on Hera and ran into a runtime error when running the SCM executable (something about not being able to find the sz.o dynamic library, potentially related to szip, hdf5, and/or use of netCDF in the code).