### PR TITLE
Some Tutorial and Docker-related updates for v6

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM dtcenter/common-community-container:gnu9
 
-MAINTAINER Michelle Harrold <harrold@ucar.edu> or Grant Firl <grantf@ucar.edu>
+MAINTAINER Michelle Harrold <harrold@ucar.edu> or Grant Firl <grantf@ucar.edu> or Michael Kavulich <kavulich@ucar.edu>
 
 #
 # Dockerfile for building CCPP SCM container
@@ -12,19 +12,30 @@ MAINTAINER Michelle Harrold <harrold@ucar.edu> or Grant Firl <grantf@ucar.edu>
 
 # Obtain CCPP SCM source code
 RUN cd /comsoftware \
-  && git clone --recursive -b v5.0.0 https://github.com/NCAR/ccpp-scm
+  && git clone --recursive -b release/public-v6 https://github.com/mkavulich/ccpp-scm
+
+# Obtain static data that was previously stored in repository
+RUN cd /comsoftware/ccpp-scm/ \
+  && . contrib/get_all_static_data.sh
 
 # Obtain the pre-computed look-up tables for running with Thompson microphysics
 RUN cd /comsoftware/ccpp-scm/ \
   && . contrib/get_thompson_tables.sh
   
-# Obtain the IN-CCN data for use with Morrison-Gettelman microphysics
-RUN cd /comsoftware/ccpp-scm/ \
-  && . contrib/get_mg_inccn_data.sh
-
 # Run the machine setup script to set environment variables
-RUN cd /comsoftware/ccpp-scm/scm/ \
-  && . etc/CENTOS_docker_setup.sh
+ENV CC=/opt/rh/devtoolset-9/root/usr/bin/gcc
+ENV CXX=/opt/rh/devtoolset-9/root/usr/bin/g++
+ENV F77=/opt/rh/devtoolset-9/root/usr/bin/gfortran
+ENV F90=/opt/rh/devtoolset-9/root/usr/bin/gfortran
+ENV FC=/opt/rh/devtoolset-9/root/usr/bin/gfortran
+
+ENV NETCDF=/comsoftware/libs/netcdf
+
+RUN cd /comsoftware/ccpp-scm/contrib \
+  && wget https://raw.githubusercontent.com/NCAR/ccpp-scm/3f501aa8af0fb00ff124d8301c932292d1d0abf3/contrib/build_nceplibs.sh \
+  && chmod +x build_nceplibs.sh \
+  && cd .. \
+  && ./contrib/build_nceplibs.sh $PWD/nceplibs
 
 ENV bacio_ROOT /comsoftware/ccpp-scm/nceplibs
 ENV sp_ROOT /comsoftware/ccpp-scm/nceplibs
@@ -54,3 +65,5 @@ RUN cd /comsoftware/ccpp-scm/scm \
 
 # Set working directory
 WORKDIR /comsoftware/ccpp-scm/scm/bin
+ENV SCM_WORK=/comsoftware
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ MAINTAINER Michelle Harrold <harrold@ucar.edu> or Grant Firl <grantf@ucar.edu> o
 
 # Obtain CCPP SCM source code
 RUN cd /comsoftware \
-  && git clone --recursive -b release/public-v6 https://github.com/mkavulich/ccpp-scm
+  && git clone --recursive -b release/public-v6 https://github.com/NCAR/ccpp-scm
 
 # Obtain static data that was previously stored in repository
 RUN cd /comsoftware/ccpp-scm/ \

--- a/scm/src/run_scm.py
+++ b/scm/src/run_scm.py
@@ -722,7 +722,7 @@ class Experiment(object):
             cmd = 'ln -sf {0} {1}'.format(os.path.join(SCM_ROOT, SCM_BIN, EXECUTABLE_NAME), os.path.join(SCM_RUN, EXECUTABLE_NAME))
             execute(cmd)
         
-        return output_dir
+        return os.path.join(SCM_RUN, output_dir)
 
 def launch_executable(use_gdb, gdb, ignore_error = False):
     """Configure model run command and pass control to shell/gdb"""
@@ -756,7 +756,8 @@ def launch_executable(use_gdb, gdb, ignore_error = False):
     
 def copy_outdir(exp_dir):
     """Copy output directory to /home for this experiment."""
-    home_output_dir = '/home/'+exp_dir
+    dir_name = os.path.basename(exp_dir)
+    home_output_dir = '/home/'+dir_name
     if os.path.isdir(home_output_dir):
         shutil.rmtree(home_output_dir)
     shutil.copytree(exp_dir, home_output_dir)

--- a/scm/src/run_scm.py
+++ b/scm/src/run_scm.py
@@ -128,8 +128,7 @@ parser.add_argument('--case_data_dir',    help='directory containing the case in
 parser.add_argument('--n_itt_out',        help='period of instantaneous output (number of timesteps)', required=False, type=int)
 parser.add_argument('--n_itt_diag',       help='period of diagnostic output (number of timesteps)', required=False, type=int)
 parser.add_argument('-dt', '--timestep',  help='timestep (s)', required=False, type=float)
-parser.add_argument('-v', '--verbose',    help='once: set logging level to debug; twice: set logging level to debug '\
-                                               'and write log to file', action='count', default=0)
+parser.add_argument('-v', '--verbose',    help='set logging level to debug and write log to file', action='count', default=0)
 
 ###############################################################################
 # Functions and subroutines                                                   #
@@ -138,19 +137,17 @@ parser.add_argument('-v', '--verbose',    help='once: set logging level to debug
 def setup_logging(verbose):
     """Sets up the logging module."""
     # print out debug messages (logs and output from subprocesses) if verbose argument is set
-    if verbose==2:
+    if verbose==1:
         LOG_LEVEL = logging.DEBUG
-    elif verbose==1:
-        LOG_LEVEL = logging.INFO
     else:
-        LOG_LEVEL = logging.WARNING
+        LOG_LEVEL = logging.INFO
     LOG_FILE = 'multi_run_scm.log'
     LOG_FORMAT = '%(levelname)s: %(message)s'
 
     logging.basicConfig(format=LOG_FORMAT, level=LOG_LEVEL)
 
     # write out a log file if verbosity is set twice (-vv)
-    if verbose > 1:
+    if verbose==1:
         fh = logging.FileHandler(LOG_FILE, mode='w')
         logger = logging.getLogger()
         logger.addHandler(fh)
@@ -814,7 +811,7 @@ def main():
         # 5. If a case list and namelist list are specified without a suite list, each case is run with the default suite
         #       specified in run_scm.py using the supplied namelists.
         if file:
-            logging.warning('Multi-run: Using {} to loop through defined runs'.format(file))
+            logging.info('Multi-run: Using {} to loop through defined runs'.format(file))
             try:
                 dirname, basename = os.path.split(file)
                 sys.path.append(dirname)
@@ -842,24 +839,24 @@ def main():
                         break
                 
                 for i, case in enumerate(scm_runs.cases,1):
-                    logging.warning('Executing process {0} of {1}: case={2}, suite={3}, namelist={4}'.format(
+                    logging.info('Executing process {0} of {1}: case={2}, suite={3}, namelist={4}'.format(
                         i, len(cases), case, active_suite._name, active_suite.namelist))
                     exp = Experiment(case, active_suite, runtime, runtime_mult, levels, npz_type, vert_coord_file, case_data_dir, n_itt_out, n_itt_diag)
                     exp_dir = exp.setup_rundir()
                     (status, time_elapsed) = launch_executable(use_gdb, gdb, ignore_error = MULTIRUN_IGNORE_ERROR)
                     if status == 0:
-                        logging.warning('Process "(case={0}, suite={1}, namelist={2}" completed successfully'.format(case, active_suite._name, active_suite.namelist))
+                        logging.info('Process "(case={0}, suite={1}, namelist={2}" completed successfully'.format(case, active_suite._name, active_suite.namelist))
                     else:
                         logging.warning('Process "(case={0}, suite={1}, namelist={2}" exited with code {3}'.format(case, active_suite._name, active_suite.namelist, status))
                     if time_elapsed:
-                        logging.warning('    Elapsed time: {0}s'.format(time_elapsed))
+                        logging.info('    Elapsed time: {0}s'.format(time_elapsed))
                     if docker:
                         copy_outdir(exp_dir)
             
             if scm_runs.cases and scm_runs.suites:
                 if scm_runs.namelists:
                     if len(scm_runs.suites) == 1:
-                        logging.warning('Cases and namelists were specified with 1 suite in {0}, so running all cases with '\
+                        logging.info('Cases and namelists were specified with 1 suite in {0}, so running all cases with '\
                             'the suite {1} for all specified namelists'.format(file, scm_runs.suites[0]))
                         
                         active_suite = None
@@ -871,22 +868,22 @@ def main():
                         for i, case in enumerate(scm_runs.cases):
                             for j, namelist in enumerate(scm_runs.namelists,1):
                                 active_suite.namelist = namelist
-                                logging.warning('Executing process {0} of {1}: case={2}, suite={3}, namelist={4}'.format(
+                                logging.info('Executing process {0} of {1}: case={2}, suite={3}, namelist={4}'.format(
                                     len(scm_runs.cases)*i+j, len(scm_runs.cases)*len(scm_runs.namelists), case, active_suite._name, active_suite.namelist))
                                 exp = Experiment(case, active_suite, runtime, runtime_mult, levels, npz_type, vert_coord_file, case_data_dir, n_itt_out, n_itt_diag)
                                 exp_dir = exp.setup_rundir()
                                 (status, time_elapsed) = launch_executable(use_gdb, gdb, ignore_error = MULTIRUN_IGNORE_ERROR)
                                 if status == 0:
-                                    logging.warning('Process "(case={0}, suite={1}, namelist={2}" completed successfully'.format(case, active_suite._name, active_suite.namelist))
+                                    logging.info('Process "(case={0}, suite={1}, namelist={2}" completed successfully'.format(case, active_suite._name, active_suite.namelist))
                                 else:
                                     logging.warning('Process "(case={0}, suite={1}, namelist={2}" exited with code {3}'.format(case, active_suite._name, active_suite.namelist, status))
                                 if time_elapsed:
-                                    logging.warning('    Elapsed time: {0}s'.format(time_elapsed))
+                                    logging.info('    Elapsed time: {0}s'.format(time_elapsed))
                                 if docker:
                                     copy_outdir(exp_dir)
                                 
                     elif len(scm_runs.suites) == len(scm_runs.namelists):
-                        logging.warning('Cases, suites, and namelists were specified in {0}, so running all cases with all '\
+                        logging.info('Cases, suites, and namelists were specified in {0}, so running all cases with all '\
                             'suites, matched with namelists by order'.format(file))
                         for i, case in enumerate(scm_runs.cases):
                             for j, suite in enumerate(scm_runs.suites,1):
@@ -898,17 +895,17 @@ def main():
                                         break
                                 
                                 active_suite.namelist = scm_runs.namelists[j-1]
-                                logging.warning('Executing process {0} of {1}: case={2}, suite={3}, namelist={4}'.format(
+                                logging.info('Executing process {0} of {1}: case={2}, suite={3}, namelist={4}'.format(
                                     len(scm_runs.cases)*i+j, len(scm_runs.cases)*len(scm_runs.suites), case, active_suite._name, active_suite.namelist))
                                 exp = Experiment(case, active_suite, runtime, runtime_mult, levels, npz_type, vert_coord_file, case_data_dir, n_itt_out, n_itt_diag)
                                 exp_dir = exp.setup_rundir()
                                 (status, time_elapsed) = launch_executable(use_gdb, gdb, ignore_error = MULTIRUN_IGNORE_ERROR)
                                 if status == 0:
-                                    logging.warning('Process "(case={0}, suite={1}, namelist={2}" completed successfully'.format(case, active_suite._name, active_suite.namelist))
+                                    logging.info('Process "(case={0}, suite={1}, namelist={2}" completed successfully'.format(case, active_suite._name, active_suite.namelist))
                                 else:
                                     logging.warning('Process "(case={0}, suite={1}, namelist={2}" exited with code {3}'.format(case, active_suite._name, active_suite.namelist, status))
                                 if time_elapsed:
-                                    logging.warning('    Elapsed time: {0}s'.format(time_elapsed))
+                                    logging.info('    Elapsed time: {0}s'.format(time_elapsed))
                                 if docker:
                                     copy_outdir(exp_dir)
                                  
@@ -919,7 +916,7 @@ def main():
                         logging.critical(message)
                         raise Exception(message)
                 else:
-                    logging.warning('Cases and suites specified in {0}, so running all cases with all suites using default '\
+                    logging.info('Cases and suites specified in {0}, so running all cases with all suites using default '\
                         'namelists for each suite'.format(file))
                     for i, case in enumerate(scm_runs.cases):
                         for j, suite in enumerate(scm_runs.suites,1):
@@ -930,22 +927,22 @@ def main():
                                     active_suite = s
                                     break                            
                             
-                            logging.warning('Executing process {0} of {1}: case={2}, suite={3}, namelist={4}'.format(
+                            logging.info('Executing process {0} of {1}: case={2}, suite={3}, namelist={4}'.format(
                                 len(scm_runs.cases)*i+j, len(scm_runs.cases)*len(scm_runs.suites), case, active_suite._name, active_suite.namelist))
                             exp = Experiment(case, active_suite, runtime, runtime_mult, levels, npz_type, vert_coord_file, case_data_dir, n_itt_out, n_itt_diag)
                             exp_dir = exp.setup_rundir()
                             (status, time_elapsed) = launch_executable(use_gdb, gdb, ignore_error = MULTIRUN_IGNORE_ERROR)
                             if status == 0:
-                                logging.warning('Process "(case={0}, suite={1}, namelist={2}" completed successfully'.format(case, active_suite._name, active_suite.namelist))
+                                logging.info('Process "(case={0}, suite={1}, namelist={2}" completed successfully'.format(case, active_suite._name, active_suite.namelist))
                             else:
                                 logging.warning('Process "(case={0}, suite={1}, namelist={2}" exited with code {3}'.format(case, active_suite._name, active_suite.namelist, status))
                             if time_elapsed:
-                                logging.warning('    Elapsed time: {0}s'.format(time_elapsed))
+                                logging.info('    Elapsed time: {0}s'.format(time_elapsed))
                             if docker:
                                 copy_outdir(exp_dir)
             
             if scm_runs.cases and not scm_runs.suites and scm_runs.namelists:
-                logging.warning('Cases and namelists were specified in {0}, so running all cases with the default suite '\
+                logging.info('Cases and namelists were specified in {0}, so running all cases with the default suite '\
                     'using the list of namelists'.format(file))
                 
                 active_suite = None
@@ -956,24 +953,24 @@ def main():
                 
                 for i, case in enumerate(scm_runs.cases):
                     for j, namelist in enumerate(scm_runs.namelists,1):
-                        logging.warning('Executing process {0} of {1}: case={2}, suite={3}, namelist={4}'.format(
+                        logging.info('Executing process {0} of {1}: case={2}, suite={3}, namelist={4}'.format(
                             len(scm_runs.cases)*i+j, len(scm_runs.cases)*len(scm_runs.namelists), case, active_suite._name, active_suite.namelist))
                         active_suite.namelist = namelist
                         exp = Experiment(case, active_suite, runtime, runtime_mult, levels, npz_type, vert_coord_file, case_data_dir, n_itt_out, n_itt_diag)
                         exp_dir = exp.setup_rundir()
                         (status, time_elapsed) = launch_executable(use_gdb, gdb, ignore_error = MULTIRUN_IGNORE_ERROR)
                         if status == 0:
-                            logging.warning('Process "(case={0}, suite={1}, namelist={2}" completed successfully'.format(case, active_suite._name, active_suite.namelist))
+                            logging.info('Process "(case={0}, suite={1}, namelist={2}" completed successfully'.format(case, active_suite._name, active_suite.namelist))
                         else:
                             logging.warning('Process "(case={0}, suite={1}, namelist={2}" exited with code {3}'.format(case, active_suite._name, active_suite.namelist, status))
                         if time_elapsed:
-                            logging.warning('    Elapsed time: {0}s'.format(time_elapsed))
+                            logging.info('    Elapsed time: {0}s'.format(time_elapsed))
                         if docker:
                             copy_outdir(exp_dir)
                         
         else:
             # Loop through all experiments
-            logging.warning('Multi-run: loop through all cases and suite definition files with standard namelists and tracer configs')
+            logging.info('Multi-run: loop through all cases and suite definition files with standard namelists and tracer configs')
             
             # determine the number of suites to run through
             active_suite_list = []
@@ -986,20 +983,20 @@ def main():
             
             for i, case in enumerate(cases):
                 for j, active_suite in enumerate(active_suite_list,1):
-                    logging.warning('Executing process {0} of {1}: case={2}, suite={3}, namelist={4}'.format(
+                    logging.info('Executing process {0} of {1}: case={2}, suite={3}, namelist={4}'.format(
                         len(active_suite_list)*i+j, len(cases)*len(active_suite_list), case, active_suite._name, active_suite.namelist))
                     exp = Experiment(case, active_suite, runtime, runtime_mult, levels, npz_type, vert_coord_file, case_data_dir, n_itt_out, n_itt_diag)
                     exp_dir = exp.setup_rundir()
                     (status, time_elapsed) = launch_executable(use_gdb, gdb, ignore_error = MULTIRUN_IGNORE_ERROR)
                     if status == 0:
-                        logging.warning('Process "(case={0}, suite={1}, namelist={2}" completed successfully'.format(case, active_suite._name, active_suite.namelist))
+                        logging.info('Process "(case={0}, suite={1}, namelist={2}" completed successfully'.format(case, active_suite._name, active_suite.namelist))
                     else:
                         logging.warning('Process "(case={0}, suite={1}, namelist={2}" exited with code {3}'.format(case, active_suite._name, active_suite.namelist, status))
                     if time_elapsed:
-                        logging.warning('    Elapsed time: {0}s'.format(time_elapsed))
+                        logging.info('    Elapsed time: {0}s'.format(time_elapsed))
                     if docker:
                         copy_outdir(exp_dir)
-        logging.warning('Done.')
+        logging.info('Done.')
         
     else:
         # Single experiment
@@ -1030,11 +1027,11 @@ def main():
         suite_string = 'suite {0}'.format(active_suite._name)
         namelist_string = 'namelist {0}'.format(active_suite.namelist)
         tracers_string = 'tracers {0}'.format(active_suite.tracers)
-        logging.warning('Setting up experiment {case} with {suite} using {namelist} and {tracers}'.format(
+        logging.info('Setting up experiment {case} with {suite} using {namelist} and {tracers}'.format(
             case=case, suite=suite_string, namelist=namelist_string, tracers=tracers_string))
         exp = Experiment(case, active_suite, runtime, runtime_mult, levels, npz_type, vert_coord_file, case_data_dir, n_itt_out, n_itt_diag)
         exp_dir = exp.setup_rundir()
-        logging.warning('Launching experiment {case} with {suite} using {namelist} and {tracers}'.format(
+        logging.info('Launching experiment {case} with {suite} using {namelist} and {tracers}'.format(
             case=case, suite=suite_string, namelist=namelist_string, tracers=tracers_string))
         # Launch model on exit
         if docker:


### PR DESCRIPTION
 - Updating Dockerfile for latest release
   - Adding myself as a maintainer
   - restoring the old NCEPLIBS build script as a stopgap before we upgrade to newest hpc-stack or spack
   - Call new data retrieval script
   - Add environment variables that are needed for running so user doesn't need to set them manually
 - Updating run script
   - Remove extra debug layer to avoid having normal messages show up as warnings
   - Update "copy_outdir" function to be able to work from any directory, not just run directory (this prevents errors in docker container)

Tests run: Used this branch (modified slightly to avoid chicken-egg problem) to build dockerfile and run tutorial case successfully with resulting docker image (can be downloaded from Dockerhub: `docker pull dtcenter/ccpp-scm:v6.0.0-beta`)