### PR TITLE
Add new conda environment to Cheyenne setup files

### DIFF
--- a/scm/etc/Cheyenne_setup_gnu.csh
+++ b/scm/etc/Cheyenne_setup_gnu.csh
@@ -50,3 +50,6 @@ setenv CMAKE_Platform cheyenne.gnu
 
 echo "Setting up python environment for running and plotting."
 module load conda/latest
+
+conda activate /glade/p/ral/jntp/GMTB/CCPP_SCM/conda/ccpp-scm
+

--- a/scm/etc/Cheyenne_setup_gnu.sh
+++ b/scm/etc/Cheyenne_setup_gnu.sh
@@ -42,3 +42,6 @@ export CMAKE_Platform=cheyenne.gnu
 
 echo "Setting up python environment for running and plotting."
 module load conda/latest
+
+conda activate /glade/p/ral/jntp/GMTB/CCPP_SCM/conda/ccpp-scm
+

--- a/scm/etc/Cheyenne_setup_intel.csh
+++ b/scm/etc/Cheyenne_setup_intel.csh
@@ -50,3 +50,6 @@ setenv CMAKE_Platform cheyenne.intel
 
 echo "Setting up python environment for running and plotting."
 module load conda/latest
+
+conda activate /glade/p/ral/jntp/GMTB/CCPP_SCM/conda/ccpp-scm
+

--- a/scm/etc/Cheyenne_setup_intel.sh
+++ b/scm/etc/Cheyenne_setup_intel.sh
@@ -42,3 +42,6 @@ export CMAKE_Platform=cheyenne.intel
 
 echo "Setting up python environment for running and plotting."
 module load conda/latest
+
+conda activate /glade/p/ral/jntp/GMTB/CCPP_SCM/conda/ccpp-scm
+


### PR DESCRIPTION
This conda environment was created using the following commands, and was sufficient to run the online tutorial case:

```
conda create --prefix=/glade/p/ral/jntp/GMTB/CCPP_SCM/conda/ccpp-scm python=3.7
conda activate /glade/p/ral/jntp/GMTB/CCPP_SCM/conda/ccpp-scm/
conda install -c conda-forge xarray dask netCDF4 bottleneck matplotlib f90nml xesmf
conda install configobj
```

It has been tested successfully with the online tutorial case for Intel with bash shell, I have not tested other configurations yet.
