### PR TITLE
Updates for ccpp-physics ufs-dev PR#14

### DIFF
--- a/scm/src/CCPP_typedefs.F90
+++ b/scm/src/CCPP_typedefs.F90
@@ -219,6 +219,7 @@ module CCPP_typedefs
     integer                             :: nday                          !<
     integer                             :: nf_aelw                       !<
     integer                             :: nf_aesw                       !<
+    integer                             :: nf_albd                       !<
     integer                             :: nn                            !<
     integer                             :: nsamftrac                     !<
     integer                             :: nscav                         !<
@@ -916,6 +917,7 @@ contains
     Interstitial%nbdsw            = NBDSW
     Interstitial%nf_aelw          = NF_AELW
     Interstitial%nf_aesw          = NF_AESW
+    Interstitial%nf_albd          = NF_ALBD
     Interstitial%nspc1            = NSPC1
     if (Model%oz_phys .or. Model%oz_phys_2015) then
       Interstitial%oz_coeffp5     = oz_coeff+5

--- a/scm/src/CCPP_typedefs.meta
+++ b/scm/src/CCPP_typedefs.meta
@@ -1460,6 +1460,12 @@
   units = count
   dimensions = ()
   type = integer
+[nf_albd]
+  standard_name = number_of_components_for_surface_albedo
+  long_name = number of IR/VIS/UV compinents for surface albedo
+  units = count
+  dimensions = ()
+  type = integer
 [nn]
   standard_name = number_of_tracers_for_convective_transport
   long_name = number of tracers for convective transport


### PR DESCRIPTION
- only new changes should be ccpp/physics submodule pointer and edits to CCPP_typedefs.F90/meta
- contains changes from #351 (that will be merged first)