### PR TITLE
UFS-dev PR#27

### DIFF
--- a/scm/src/GFS_typedefs.F90
+++ b/scm/src/GFS_typedefs.F90
@@ -1175,6 +1175,7 @@ module GFS_typedefs
     real(kind=kind_phys) :: rlmx            !< maximum allowed mixing length in boundary layer mass flux scheme
     real(kind=kind_phys) :: elmx            !< maximum allowed dissipation mixing length in boundary layer mass flux scheme
     integer              :: sfc_rlm         !< choice of near surface mixing length in boundary layer mass flux scheme
+    integer              :: tc_pbl          !< control for TC applications in the PBL scheme
 
 !--- parameters for canopy heat storage (CHS) parameterization
     real(kind=kind_phys) :: h0facu          !< CHS factor for sensible heat flux in unstable surface layer
@@ -3340,6 +3341,7 @@ module GFS_typedefs
     real(kind=kind_phys) :: rlmx           = 300.            !< maximum allowed mixing length in boundary layer mass flux scheme
     real(kind=kind_phys) :: elmx           = 300.            !< maximum allowed dissipation mixing length in boundary layer mass flux scheme
     integer              :: sfc_rlm        = 0               !< choice of near surface mixing length in boundary layer mass flux scheme
+    integer              :: tc_pbl         = 0               !< control for TC applications in the PBL scheme
 
 !--- parameters for canopy heat storage (CHS) parameterization
     real(kind=kind_phys) :: h0facu         = 0.25
@@ -3543,7 +3545,7 @@ module GFS_typedefs
                                thsfc_loc,                                                   &
                           !    vertical diffusion
                                xkzm_m, xkzm_h, xkzm_s, xkzminv, moninq_fac, dspfac,         &
-                               bl_upfr, bl_dnfr, rlmx, elmx, sfc_rlm,                       &
+                               bl_upfr, bl_dnfr, rlmx, elmx, sfc_rlm, tc_pbl,               &
                           !--- canopy heat storage parameterization
                                h0facu, h0facs,                                              &
                           !--- cellular automata
@@ -4374,6 +4376,7 @@ module GFS_typedefs
     Model%rlmx             = rlmx
     Model%elmx             = elmx
     Model%sfc_rlm          = sfc_rlm
+    Model%tc_pbl           = tc_pbl
 
 !--- canopy heat storage parametrization
     Model%h0facu           = h0facu
@@ -6062,6 +6065,7 @@ module GFS_typedefs
       print *, ' rlmx              : ', Model%rlmx
       print *, ' elmx              : ', Model%elmx
       print *, ' sfc_rlm           : ', Model%sfc_rlm
+      print *, ' tc_pbl            : ', Model%tc_pbl
       print *, ' '
       print *, 'parameters for canopy heat storage parametrization'
       print *, ' h0facu            : ', Model%h0facu

--- a/scm/src/GFS_typedefs.meta
+++ b/scm/src/GFS_typedefs.meta
@@ -5016,6 +5016,12 @@
   units = none
   dimensions = ()
   type = integer
+[tc_pbl]
+  standard_name = control_for_TC_applications_in_the_PBL_scheme
+  long_name = control for TC applications in the PBL scheme
+  units = none
+  dimensions = ()
+  type = integer
 [h0facu]
   standard_name = multiplicative_tuning_parameter_for_reduced_surface_heat_fluxes_due_to_canopy_heat_storage
   long_name = canopy heat storage factor for sensible heat flux in unstable surface layer


### PR DESCRIPTION
This updates GFS_typedefs to work with the latest ccpp/physics on the NCAR fork, main branch.

Associated PRs:
https://github.com/NCAR/ccpp-physics/pull/992
https://github.com/NCAR/fv3atm/pull/79
https://github.com/NCAR/ufs-weather-model/pull/81