### PR TITLE
update .gitmodules to point to main

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,10 +4,8 @@
 	branch = main
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	#url = https://github.com/NCAR/ccpp-physics
-	#branch = main
-        url = https://github.com/grantfirl/ccpp-physics
-        branch = ufs-dev-PR71
+	url = https://github.com/NCAR/ccpp-physics
+	branch = main
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules


### PR DESCRIPTION
Hotfix for .gitmodules accidentally not pointing to NCAR/main.