### PR TITLE
UFS-dev PR#69

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
 	#url = https://github.com/NCAR/ccpp-physics
 	#branch = main
         url = https://github.com/grantfirl/ccpp-physics
-        branch = ufs-dev-PR88
+        branch = ufs-dev-PR69
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,10 +4,8 @@
 	branch = main
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	#url = https://github.com/NCAR/ccpp-physics
-	#branch = main
-        url = https://github.com/grantfirl/ccpp-physics
-        branch = ufs-dev-PR69
+	url = https://github.com/NCAR/ccpp-physics
+	branch = main
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules


### PR DESCRIPTION
Only update to ccpp/physics submodule necessary (no changes to typedefs).

includes changes from #402 until it is merged.