### PR TITLE
Use spack-stack-1.5.1 on Hera with Intel (sh so far only)

### DIFF
--- a/scm/etc/Hera_setup_intel.sh
+++ b/scm/etc/Hera_setup_intel.sh
@@ -7,33 +7,19 @@ MYDIR=$(cd "$(dirname "$(readlink -f -n "${BASH_SOURCE[0]}" )" )" && pwd -P)
 export SCM_ROOT=$MYDIR/../..
 
 #load the modules in order to compile the CCPP SCM
-echo "Loading intel and netcdf modules..."
+echo "Loading spack-stack modules..."
 module purge
-module load intel/2022.1.2
-module load impi/2022.1.2
-module use /scratch1/NCEPDEV/nems/role.epic/hpc-stack/libs/intel-2022.1.2/modulefiles/stack
-module load hpc/1.2.0
-module load hpc-intel/2022.1.2
-module load hpc-impi/2022.1.2
-module load netcdf
+#module use /scratch1/NCEPDEV/jcsda/jedipara/spack-stack/modulefiles
+module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.1/envs/unified-env/install/modulefiles/Core
+module load stack-intel/2021.5.0
+module load stack-intel-oneapi-mpi/2021.5.1
+module load stack-python/3.10.8
+module load netcdf-fortran/4.6.0
+module load bacio/2.4.1
+module load sp/2.3.3
+module load w3emc/2.10.0
+module load py-f90nml/1.4.3
+module load cmake/3.23.1
 
-echo "Setting up NCEPLIBS"
-export bacio_ROOT=/scratch1/NCEPDEV/nems/role.epic/hpc-stack/libs/intel-2022.1.2/intel-2022.1.2/bacio/2.4.1
-export sp_ROOT=/scratch1/NCEPDEV/nems/role.epic/hpc-stack/libs/intel-2022.1.2/intel-2022.1.2/sp/2.3.3
-export w3emc_ROOT=/scratch1/NCEPDEV/nems/role.epic/hpc-stack/libs/intel-2022.1.2/intel-2022.1.2/w3emc/2.9.2
-
-echo "Setting CC/CXX/FC environment variables"
-export CC=icc
-export CXX=icpc
-export FC=ifort
-
-echo "Loading cmake"
-module load cmake/3.20.1
-export CMAKE_C_COMPILER=icc
-export CMAKE_CXX_COMPILER=icpc
-export CMAKE_Fortran_COMPILER=ifort
 export CMAKE_Platform=hera.intel
 
-echo "Loading the SCM python environment"
-. "/scratch1/BMC/gmtb/SCM_anaconda/etc/profile.d/conda.sh"
-conda activate pyccpp


### PR DESCRIPTION
Switch to spack-stack-1.5.1 - so far only Hera/Intel and bash. I was able to compile the scm with this, didn't run the tests yet.

The only thing that is missing is doxygen, which is optional for building the documentation.