### PR TITLE
Workflow ci_run_scm_rts Versioning Bugfix

### DIFF
--- a/.github/workflows/ci_build_scm_ubuntu_22.04.yml
+++ b/.github/workflows/ci_build_scm_ubuntu_22.04.yml
@@ -37,7 +37,7 @@ jobs:
 
     #######################################################################################
     # Python setup
-    #######################################################################################    
+    #######################################################################################
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
@@ -47,10 +47,9 @@ jobs:
       run: |
         echo $CONDA/bin >> $GITHUB_PATH
 
-    - name: Install python libraries
+    - name: Install NetCDF Python libraries
       run: |
-        conda install --yes -c conda-forge f90nml
-        conda install --yes -c conda-forge netCDF4
+        conda install --yes -c conda-forge h5py>=3.4 netCDF4 f90nml
 
     - name: Update system packages
       run: sudo apt-get update

--- a/.github/workflows/ci_run_scm_DEPHY.yml
+++ b/.github/workflows/ci_run_scm_DEPHY.yml
@@ -35,7 +35,7 @@ jobs:
 
     #######################################################################################
     # Python setup
-    #######################################################################################    
+    #######################################################################################
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
@@ -44,10 +44,10 @@ jobs:
     - name: Add conda to system path
       run: |
         echo $CONDA/bin >> $GITHUB_PATH
-    - name: Install python libraries
+    - name: Install NetCDF Python libraries
       run: |
-        conda install --yes -c conda-forge f90nml
-        conda install --yes -c conda-forge netCDF4
+        conda install --yes -c conda-forge h5py>=3.4 netCDF4 f90nml
+
     - name: Update system packages
       run: sudo apt-get update
 

--- a/.github/workflows/ci_run_scm_rts.yml
+++ b/.github/workflows/ci_run_scm_rts.yml
@@ -39,7 +39,7 @@ jobs:
 
     #######################################################################################
     # Python setup
-    #######################################################################################    
+    #######################################################################################
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
@@ -49,10 +49,9 @@ jobs:
       run: |
         echo $CONDA/bin >> $GITHUB_PATH
 
-    - name: Install python libraries
+    - name: Install NetCDF Python libraries
       run: |
-        conda install --yes -c conda-forge f90nml
-        conda install --yes -c conda-forge netCDF4
+        conda install --yes -c conda-forge h5py>=3.4 netCDF4 f90nml
 
     - name: Update system packages
       run: sudo apt-get update
@@ -198,6 +197,6 @@ jobs:
 
     - name: Upload SCM RTs as GitHub Artifact
       uses: actions/upload-artifact@v2
-      with: 
+      with:
         name: rt-baselines-${{matrix.build-type}}
         path: /home/runner/work/ccpp-scm/ccpp-scm/test/artifact-${{matrix.build-type}}


### PR DESCRIPTION
DESCRIPTION OF CHANGES: Using h5py>=3.4 to avoid 'H5Pset_fapl_ros3 is undefined' error within Conda's Python NetCDF installation.

TESTS CONDUCTED: Passes ci_run_scm_rts 

NOTES: ~If this versioning issue effects the other GitHub action workflows, I'll edit this PR to fix the others.~ It did effect other workflows, copied the changes to those files as well.

