### PR TITLE
Recude GNU Compilation Warnings

### DIFF
--- a/scm/src/GFS_typedefs.F90
+++ b/scm/src/GFS_typedefs.F90
@@ -3161,6 +3161,7 @@ module GFS_typedefs
                                  communicator, ntasks, nthreads)
 
 !--- modules
+    use w3emc,            only: w3difdat
     use physcons,         only: con_rerth, con_pi, con_p0, rhowater
     use mersenne_twister, only: random_setseed, random_number
     use parse_tracers,    only: get_tracer_index

--- a/scm/src/GFS_typedefs.meta
+++ b/scm/src/GFS_typedefs.meta
@@ -9665,6 +9665,7 @@
   relative_path = ../../ccpp/physics/physics
   dependencies = machine.F,physcons.F90,radlw_param.f,radsw_param.f
   dependencies = GFDL_parse_tracers.F90,h2o_def.f,ozne_def.f,GFS_ccpp_suite_sim_pre.F90
+  dependencies = w3emc_wrapper.F90
 
 [ccpp-arg-table]
   name = GFS_typedefs


### PR DESCRIPTION
This PR fixes warnings from the w3emc library warnings because they don't use generic interfaces

The w3emc module [commit](https://github.com/NCAR/ccpp-physics/compare/main...scrasmussen:ccpp-physics:compiler-warning-reduction/50d2918e8c3ebf8b962eac456b54174c30740f92) is just a wrapper to the normal w3emc w3difdat and w3movdat functions but uses generic interfaces in a single file. This means the type warnings only are produced once when compiling the wrapper module, rather than in every file that calls w3difdat and w3movdat. This wrapper file module can easily be removed in the future if the w3emc library decides to move to generic interfaces.

This PR almost fulfills the GNU compiler part of the requirement "Code must compile without errors or warnings. Errors and warnings may not be suppressed, and the compiler warning level ("-W" options) must be at least the default one." as pointed out in https://github.com/ufs-community/ufs-weather-model/issues/1984#issuecomment-1799297076. It also a step towards fulfulling the goal/requirement of no warnings from -Wall, as pointed out in https://github.com/NCAR/ccpp-physics/issues/495.