### PR TITLE
bugfix: CMake build missing mpi_f08 module paths

### DIFF
--- a/scm/src/CMakeLists.txt
+++ b/scm/src/CMakeLists.txt
@@ -71,6 +71,10 @@ find_package(NetCDF REQUIRED COMPONENTS C Fortran)
 find_package(bacio REQUIRED)
 find_package(sp    REQUIRED)
 find_package(w3emc REQUIRED)
+find_package(MPI   REQUIRED)
+if(NOT MPI_Fortran_HAVE_F08_MODULE)
+  message(FATAL_ERROR "MPI_F08 Required")
+endif()
 
 SET(CCPP_FRAMEWORK_SRC ${CMAKE_SOURCE_DIR}/../../ccpp/framework)
 SET(CCPP_PHYSICS_SRC ${CMAKE_SOURCE_DIR}/../../ccpp/physics)
@@ -90,6 +94,7 @@ endif()
 
 INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/ccpp/framework/src)
 INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR}/ccpp/physics)
+include_directories(${MPI_Fortran_INCLUDE_PATH})
 
 #------------------------------------------------------------------------------
 # Add required preprocessor flags for build type


### PR DESCRIPTION
The fix 
- finds the MPI package and requires `mpi_f08` module. 
- include the MPI module paths, this fixes the following `use mpi_f08` error in `framework/src/ccpp_types.F90`

Current Error:
```
$ make
[  0%] Building Fortran object ccpp/framework/src/CMakeFiles/ccpp_framework.dir/ccpp_types.F90.o
/glade/work/soren/src/ccpp/upstream/scm-upstream/ccpp/framework/src/ccpp_types.F90:22:9:

   22 |     use mpi_f08, only: MPI_Comm
      |         1
Fatal Error: Cannot open module file 'mpi_f08.mod' for reading at (1): No such file or directory
compilation terminated.

```