### PR TITLE
update case-gen scripts for LAM capability

### DIFF
--- a/scm/etc/scripts/UFS_case_gen.py
+++ b/scm/etc/scripts/UFS_case_gen.py
@@ -459,12 +459,15 @@ def find_lon_lat_of_indices(indices, dir, tile, lam):
 ########################################################################################
 #
 ########################################################################################
-def find_loc_indices_UFS_history(loc, dir):
+def find_loc_indices_UFS_history(loc, dir, lam):
     """Find the nearest neighbor UFS history file grid point given a lon/lat pair"""
     #returns the indices of the nearest neighbor point in the given tile, the lon/lat of the nearest neighbor, 
     #and the distance (m) from the given point to the nearest neighbor grid cell
-    
-    filename_pattern = 'atmf000.nc'
+
+    if lam:
+        filename_pattern = 'dynf000.nc'
+    else: 
+        filename_pattern = 'atmf000.nc'
     
     for f_name in os.listdir(dir):
        if fnmatch.fnmatch(f_name, filename_pattern):
@@ -657,7 +660,7 @@ def check_IC_hist_surface_compatibility(dir, i, j, surface_data, lam, old_chgres
     
     # Determine UFS history file format (tiled/quilted)
     if lam:
-        filename_pattern = '*sfcf000.tile{}.nc'.format(tile)
+        filename_pattern = '*phyf000.nc'
     else:
         filename_pattern = '*sfcf000.nc'
     
@@ -738,7 +741,7 @@ def get_IC_data_from_UFS_history(dir, i, j, lam, tile):
     
     # Determine UFS history file format (tiled/quilted)
     if lam:
-        filename_pattern = '*atmf000.tile{}.nc'.format(tile)
+        filename_pattern = '*dynf000.nc'
     else:
         filename_pattern = '*atmf000.nc'
     
@@ -1956,8 +1959,8 @@ def get_UFS_forcing_data_advective_tendency(dir, i, j, tile, neighbors, dx, dy, 
     
     # Determine UFS history file format (tiled/quilted)
     if lam:
-        atm_ftag = 'atmf*.tile{0}.nc'.format(tile)
-        sfc_ftag = 'sfcf*.tile{0}.nc'.format(tile)
+        atm_ftag = '*dynf*.nc'
+        sfc_ftag = '*phyf*.nc'
     else:
         atm_ftag = '*atmf*.nc'
         sfc_ftag = '*sfcf*.nc'
@@ -2308,8 +2311,8 @@ def get_UFS_forcing_data(nlevs, state_IC, location, use_nearest, forcing_dir, gr
 
     # Determine UFS history file format (tiled/quilted)
     if lam:
-        atm_ftag = 'atmf*.tile{0}.nc'.format(tile)
-        sfc_ftag = 'sfcf*.tile{0}.nc'.format(tile)
+        atm_ftag = '*dynf*.nc'
+        sfc_ftag = '*phyf*.nc'
     else:
         atm_ftag = '*atmf*.nc'
         sfc_ftag = '*sfcf*.nc'
@@ -3625,9 +3628,12 @@ def write_comparison_file(comp_data, case_name, date, surface):
 ########################################################################################
 #
 ########################################################################################
-def find_date(forcing_dir):
-    
-    atm_ftag = '*atmf*.nc'
+def find_date(forcing_dir, lam):
+
+    if lam:
+        atm_ftag = '*dynf*.nc'
+    else:    
+        atm_ftag = '*atmf*.nc'
     
     atm_filenames = []
     for f_name in os.listdir(forcing_dir):
@@ -3668,7 +3674,7 @@ def main():
      old_chgres, lam, save_comp, use_nearest, forcing_method, vertical_method, geos_wind_forcing, wind_nudge) = parse_arguments()
     
     #find indices corresponding to both UFS history files and initial condition (IC) files
-    (hist_i, hist_j, hist_lon, hist_lat, hist_dist_min, angle_to_hist_point, neighbors, dx, dy) = find_loc_indices_UFS_history(location, forcing_dir)
+    (hist_i, hist_j, hist_lon, hist_lat, hist_dist_min, angle_to_hist_point, neighbors, dx, dy) = find_loc_indices_UFS_history(location, forcing_dir, lam)
     
     (IC_i, IC_j, tile, IC_lon, IC_lat, IC_dist_min, angle_to_IC_point) = find_loc_indices_UFS_IC(location, grid_dir, lam, tile, indices)
         
@@ -3704,7 +3710,7 @@ def main():
 
     if not date:
         # date was not included on command line; look in atmf* file for initial date
-        date = find_date(forcing_dir)
+        date = find_date(forcing_dir, lam)
     
     #get grid cell area if not given
     if not area:

--- a/scm/etc/scripts/UFS_forcing_ensemble_generator.py
+++ b/scm/etc/scripts/UFS_forcing_ensemble_generator.py
@@ -27,6 +27,7 @@ parser.add_argument('-cres', '--C_RES',          help='UFS spatial resolution', 
 parser.add_argument('-sdf',  '--suite',          help='CCPP suite definition file to use for ensemble',                            default = 'SCM_GFS_v16')
 parser.add_argument('-sc',   '--save_comp',      help='flag to save a file with UFS data for comparisons',                           action='store_true')
 parser.add_argument('-near', '--use_nearest',    help='flag to indicate using the nearest UFS history file gridpoint, no regridding',action='store_true')
+parser.add_argument('-lam',  '--lam',            help='flag to signal that the ICs and forcing is from a limited-area model run'    ,action='store_true')
 parser.add_argument('-fm',   '--forcing_method', help='method used to calculate forcing (1=total tendencies from UFS dycore, 2=advective terms calculated from UFS history files, 3=total time tendency terms calculated)', type=int, choices=range(1,4), default=2)
 parser.add_argument('-vm',   '--vertical_method',help='method used to calculate vertical advective forcing (1=vertical advective terms calculated from UFS history files and added to total, 2=smoothed vertical velocity provided)', type=int, choices=range(1,3), default=2)
 parser.add_argument('-wn',   '--wind_nudge',     help='flag to turn on wind nudging to UFS profiles',                                action='store_true')
@@ -142,6 +143,7 @@ def main():
     com_config = ''
     if args.save_comp:       com_config = com_config + ' -sc'
     if args.use_nearest:     com_config = com_config + ' -near'
+    if args.lam:             com_config = com_config + ' -lam'
     if args.forcing_method:  com_config = com_config + ' -fm ' + str(args.forcing_method)
     if args.vertical_method: com_config = com_config + ' -vm ' + str(args.vertical_method)
     if args.wind_nudge:      com_config = com_config + ' -wn'


### PR DESCRIPTION
Running the case generation on LAM output from UFS SRW does not currently work. These updates fix that.

Sample LAM data can be found on Hera: /scratch1/BMC/gmtb/Tracy.Hertneky/phys_tne/socrates/2018020412

Sample case over the S. Ocean was created with the following command:

./UFS_forcing_ensemble_generator.py -d /scratch1/BMC/gmtb/Tracy.Hertneky/phys_tne/socrates/2018020412 -n socrates -lons 133 -lats -51.5 -dt 75 -cres 768 -sdf SCM_GFS_v16 -sc -lam -fm 2 -vm 2

./run_scm.py --npz_type gfs --file scm_ufsens_socrates.py --timestep 75 -l 64 --n_itt_out 48 --n_itt_diag 48

Comparison of SCM to UFS column:
Diffs could be attributable to diff suite used (HRRR_gf for UFS vs GFS_v16 for SCM, since HRRR_gf was not working from case_gen input)
![Screenshot 2024-07-31 at 3 04 52 PM](https://github.com/user-attachments/assets/201d2b61-6ab8-4a21-af38-c7bc995a777f)
