### PR TITLE
bugfix: Default MPI Command

### DIFF
--- a/scm/src/run_scm.py
+++ b/scm/src/run_scm.py
@@ -121,7 +121,7 @@ parser.add_argument('-dt', '--timestep',  help='timestep (s)', required=False, t
 parser.add_argument('--stop_on_error',    help='when running multiple SCM runs, stop on first error', required=False, action='store_true')
 parser.add_argument('-v', '--verbose',    help='set logging level to debug and write log to file', action='count', default=0)
 parser.add_argument('-f', '--file',       help='name of file where SCM runs are defined')
-parser.add_argument('--mpi_command',      help='command used to invoke the executable via MPI (including options)', required=False, default=False)
+parser.add_argument('--mpi_command',      help='command used to invoke the executable via MPI (including options)', required=False, default='')
 
 ###############################################################################
 # Functions and subroutines                                                   #
@@ -724,9 +724,6 @@ class Experiment(object):
 def launch_executable(use_gdb, gdb, mpi_command, ignore_error = False):
     """Configure model run command and pass control to shell/gdb"""
 
-    # If mpi_command flag not passed default to '' to allow it to run on login nodes
-    if not mpi_command:
-        mpi_command = ''
     if use_gdb:
         if mpi_command != '' and ('xterm' not in mpi_command):
             logging.info("run_scm.py debug flag adds 'xterm -e' to MPI command")

--- a/scm/src/run_scm.py
+++ b/scm/src/run_scm.py
@@ -121,7 +121,7 @@ parser.add_argument('-dt', '--timestep',  help='timestep (s)', required=False, t
 parser.add_argument('--stop_on_error',    help='when running multiple SCM runs, stop on first error', required=False, action='store_true')
 parser.add_argument('-v', '--verbose',    help='set logging level to debug and write log to file', action='count', default=0)
 parser.add_argument('-f', '--file',       help='name of file where SCM runs are defined')
-parser.add_argument('--mpi_command',      help='command used to invoke the executable via MPI (including options)', required=False, default='')
+parser.add_argument('--mpi_command',      help='command used to invoke the executable via MPI (including options)', required=False, default='mpirun -np 1')
 
 ###############################################################################
 # Functions and subroutines                                                   #


### PR DESCRIPTION
DESCRIPTION OF ISSUES AND CHANGES:
- On login nodes for most clusters the `mpiexec` or `mpirun` command will not run, even if a single process is requested. The default MPI command was `mpirun -np 1`, default MPI command now changed to ''.
- Various MPI implementations might have different flags for debugging so defaulting to `xterm -e` could potentially cause issues. It probably won't be an issue, so script only reports that it adds 'xterm -e' to MPI command if debug mode turned on and `xterm` was not passed by the user.