### PR TITLE
v7 release: --mpi_command documentation and scm_qsub_example.py fix

### DIFF
--- a/scm/doc/TechGuide/chap_quick.rst
+++ b/scm/doc/TechGuide/chap_quick.rst
@@ -594,6 +594,12 @@ If using the main branch, you should run the above command to ensure you have th
    -  Use this to specify the timestep to use (if different than the
       default specified in ``../src/suite_info.py``).
 
+-  ``--mpi_command``
+
+   -  Provide argument to define the MPI command that will be invoked.
+      Default MPI command is ``mpirun -np 1``.
+      (Note: to run on a Derecho login node the empty argument ``--mpi_command ''`` is required.)
+
 -  ``--verbose [-v]``
 
    -  Use this option to see additional debugging output from the run
@@ -876,7 +882,7 @@ Running the Docker image
 
 #. To run the SCM, you can run the Docker container that was just
    created and give it the same run commands as discussed in :numref:`Section %s <singlerunscript>`
-   **Be sure to remember to include the ``-d`` and ``--mpi_command "mpirun -np 1 --allow-run-as-root"`` 
+   **Be sure to remember to include the ``-d`` and ``--mpi_command "mpirun -np 1 --allow-run-as-root"``
    options for all run commands**. For example,
 
    .. code:: bash

--- a/scm/etc/scm_qsub_example.py
+++ b/scm/etc/scm_qsub_example.py
@@ -34,7 +34,7 @@ ACCOUNT = "ENTER_ACCOUNT_NUMBER"
 WALLTIME = "walltime=00:20:00"
 PROCESSORS = "select=1:ncpus=1"
 QUEUE = "develop"
-COMMAND = "./run_scm.py -c twpice"
+COMMAND = "cd $PBS_O_WORKDIR; ./run_scm.py -c twpice"
 EMAIL_ADDR = MY_EMAIL
 SERIAL_MEM = "512M"
 WORKING_DIR = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
LIST OF CHANGES
- Adding documentation for `run_scm.py`'s `--mpi_command` argument
- Batch script `scm_qsub_example.py` needed `cd $PBS_O_WORKDIR` added to the command so it would work on Derecho