### PR TITLE
README v7 Updates With Build and Zenodo Badges

### DIFF
--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -1,4 +1,5 @@
-name: CI test to run SCM ccpp_prebuild script
+# CI test to run SCM ccpp_prebuild script
+name: build
 
 on: [push, pull_request, workflow_dispatch]
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
-# User's Guide
+# Single Column Model (SCM)
 
-Please find the up-to-date User's Guide located on ReadTheDocs: https://ccpp-scm.readthedocs.io/en/latest/
+[![Build Status](https://github.com/NCAR/ccpp-scm/actions/workflows/ci_scm_ccpp_prebuild.yml/badge.svg?branch=main)](https://github.com/NCAR/ccpp-scm/actions/workflows/ci_scm_ccpp_prebuild.yml)
+[![Release](https://img.shields.io/github/release/NCAR/ccpp-scm.svg)](https://github.com/NCAR/ccpp-scm/releases/latest)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.13156711.svg)](https://doi.org/10.5281/zenodo.13156711)
+<!-- v7.0.0 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.13738129.svg)](https://doi.org/10.5281/zenodo.13738129) -->
+
+The SCM is a tool for developing physics suites and diagnosing their performance. This SCM works with the
+- [Common Community Physics Package (CCPP):](https://github.com/NCAR/ccpp-physics) a library of physical parameterizations for atmospheric numerical models.
+- [CCPP Framework:](https://github.com/NCAR/ccpp-scm:) a framework for connecting atmospheric models to physics suites.
+
+## Documentation
+- [SCM readthedocs](https://ccpp-scm.readthedocs.io/en/v7.0.0/)
+- [CCPP readthedocs](https://ccpp-techdoc.readthedocs.io/en/v7.0.0/)
+- [Scientific documentation](https://dtcenter.ucar.edu/GMTB/v7.0.0/sci_doc/index.html)


### PR DESCRIPTION
### DESCRIPTION OF CHANGES
- Updating README with v7 documentation and adding build, version, and Zenodo badges. 
- Added short description of SCM with links to CCPP and Framework repos.
- Renaming Github Action so Github Action badge will say "build" instead of "CI test to run SCM ccpp_prebuild scipt".

#### README Preview
<img width="600" alt="image" src="https://github.com/user-attachments/assets/1ece6094-70f4-4d0a-91a2-34fb71e0bdb9">
