### PR TITLE
Physics cleanup for Capgen transition

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
 	branch = main
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = main
+	url = https://github.com/dustinswales/ccpp-physics
+	branch = changes_for_capgen
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules


### PR DESCRIPTION
This PR contains changes to the underlying physics, and no changes to the SCM. 
See [NCAR:ccpp-pysics #1085 ](https://github.com/NCAR/ccpp-physics/pull/1085)for a description of the changes.