### PR TITLE
Docs: Updating link to support forum

### DIFF
--- a/scm/doc/TechGuide/chap_ccpp.rst
+++ b/scm/doc/TechGuide/chap_ccpp.rst
@@ -380,4 +380,4 @@ called ‘smoke’.
    physics (``ccpp-scm/scm/src/GFS_typedefs.F90/GFS_stateout_type/gq0``). If the tracer needs to be part of these arrays, there are
    a few additional steps to take. If you need help, please post on the
    support forum at:
-   https://dtcenter.org/forum/ccpp-user-support/ccpp-single-column-model.
+   https://github.com/NCAR/ccpp-scm/discussions


### PR DESCRIPTION
## Description of Changes: 
Support forum link was pointing to old url that doesn't exist anymore.

## Issue
This PR will complete the final task in Issue #422 