### PR TITLE
bugfix: broken CCPP Framework link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 The SCM is a tool for developing physics suites and diagnosing their performance. This SCM works with the
 - [Common Community Physics Package (CCPP):](https://github.com/NCAR/ccpp-physics) a library of physical parameterizations for atmospheric numerical models.
-- [CCPP Framework:](https://github.com/NCAR/ccpp-scm:) a framework for connecting atmospheric models to physics suites.
+- [CCPP Framework:](https://github.com/NCAR/ccpp-framework) a framework for connecting atmospheric models to physics suites.
 
 ## Documentation
 - [SCM readthedocs](https://ccpp-scm.readthedocs.io/en/v7.0.0/)


### PR DESCRIPTION
A small single `:` was breaking the CCPP Framework link in the README. This should be a quick one to review. 😉 