### PR TITLE
Contrib data script's wget verbosity

### DIFF
--- a/contrib/get_aerosol_climo.sh
+++ b/contrib/get_aerosol_climo.sh
@@ -1,5 +1,35 @@
 #!/bin/bash
 
+# Function to display help message
+print_help() {
+    echo "get_aerosol_climo.sh: contrib/get_aerosol_climo.sh [-v,--verbose]"
+    echo "    Script for downloading/extracting the GOCART climatological aerosol data."
+    echo ""
+    echo "Options:"
+    echo "    -v, --verbose    Turn on wget verbose output."
+    echo "    --help           Show this help message and exit."
+}
+
+verbose="-nv"
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --help)
+            print_help
+            exit 0
+            ;;
+        -v|--verbose)
+            verbose="-v"
+            ;;
+        *)
+            echo "Unknown option: $1"
+            print_help
+            exit 1
+            ;;
+    esac
+    shift
+done
+
 #set -ex
 
 # Directory where this script is located
@@ -20,10 +50,9 @@ data_files=("FV3_aeroclim1" "FV3_aeroclim2" "FV3_aeroclim3" "FV3_aeroclim_optics
 cd $BASEDIR/scm/data/physics_input_data/
 for file in "${data_files[@]}"; do
     echo "Retrieving $file.tar.gz"
-    wget https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/${file}.tar.gz
+    wget ${verbose} https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/${file}.tar.gz
     tar -xvf ${file}.tar.gz
     rm -f ${file}.tar.gz
 done
 
 cd $BASEDIR/
-

--- a/contrib/get_all_static_data.sh
+++ b/contrib/get_all_static_data.sh
@@ -1,5 +1,35 @@
 #!/bin/bash
 
+# Function to display help message
+print_help() {
+    echo "get_all_static_data.sh: contrib/get_all_static_data.sh [-v,--verbose]"
+    echo "    Script for downloading/extracting the processed SCM case data."
+    echo ""
+    echo "Options:"
+    echo "    -v, --verbose    Turn on wget verbose output."
+    echo "    --help           Show this help message and exit."
+}
+
+verbose="-nv"
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --help)
+            print_help
+            exit 0
+            ;;
+        -v|--verbose)
+            verbose="-v"
+            ;;
+        *)
+            echo "Unknown option: $1"
+            print_help
+            exit 1
+            ;;
+    esac
+    shift
+done
+
 #set -ex
 
 # Directory where this script is located
@@ -21,10 +51,9 @@ for file in "${data_files[@]}"; do
     mkdir -p $BASEDIR/scm/data/$file
     cd $BASEDIR/scm/data/$file
     echo "Retrieving $file"
-    wget https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/${file}.tar.gz
+    wget ${verbose} https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/${file}.tar.gz
     tar -xf ${file}.tar.gz
     rm -f ${file}.tar.gz
 done
 
 cd $BASEDIR/
-

--- a/contrib/get_mg_inccn_data.sh
+++ b/contrib/get_mg_inccn_data.sh
@@ -1,5 +1,35 @@
 #!/bin/bash
 
+# Function to display help message
+print_help() {
+    echo "get_mg_inccn_data.sh: contrib/get_mg_inccn_data.sh [-v,--verbose]"
+    echo "    Script for downloading/extracting the Morrison-Gettelman data."
+    echo ""
+    echo "Options:"
+    echo "    -v, --verbose    Turn on wget verbose output."
+    echo "    --help           Show this help message and exit."
+}
+
+verbose="-nv"
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --help)
+            print_help
+            exit 0
+            ;;
+        -v|--verbose)
+            verbose="-v"
+            ;;
+        *)
+            echo "Unknown option: $1"
+            print_help
+            exit 1
+            ;;
+    esac
+    shift
+done
+
 set -ex
 
 # Directory where this script is located
@@ -16,8 +46,7 @@ BASEDIR=$MYDIR/..
 
 # Change to directory containing the physics input data, download and extract archive
 cd $BASEDIR/scm/data/physics_input_data/
-wget https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/MG_INCCN_data.tar.gz
+wget ${verbose} https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/MG_INCCN_data.tar.gz
 tar -xvf MG_INCCN_data.tar.gz
 rm -f MG_INCCN_data.tar.gz
 cd $BASEDIR/
-

--- a/contrib/get_thompson_tables.sh
+++ b/contrib/get_thompson_tables.sh
@@ -1,5 +1,35 @@
 #!/bin/bash
 
+# Function to display help message
+print_help() {
+    echo "get_thompson_tables.sh: contrib/get_thompson_tables.sh [-v,--verbose]"
+    echo "    Script for downloading/extracting the Thompson lookup tables."
+    echo ""
+    echo "Options:"
+    echo "    -v, --verbose    Turn on wget verbose output."
+    echo "    --help           Show this help message and exit."
+}
+
+verbose="-nv"
+# Parse command-line arguments
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        --help)
+            print_help
+            exit 0
+            ;;
+        -v|--verbose)
+            verbose="-v"
+            ;;
+        *)
+            echo "Unknown option: $1"
+            print_help
+            exit 1
+            ;;
+    esac
+    shift
+done
+
 set -ex
 
 if [[ $(uname -s) == Darwin ]]; then
@@ -15,8 +45,7 @@ BASEDIR=$MYDIR/..
 
 # Change to directory containing the physics input data, download and extract archive
 cd $BASEDIR/scm/data/physics_input_data/
-wget https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/thompson_tables.tar.gz
+wget ${verbose} https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/thompson_tables.tar.gz
 tar -xvf thompson_tables.tar.gz
 rm -f thompson_tables.tar.gz
 cd $BASEDIR/
-


### PR DESCRIPTION
## Issue
The Github Actions logs are being filled up with output from the `wget` download status bar.

## Description of Changes
Added ability to turn on verbose wget output. Wget output defaults to `-nv` so that the Github Actions output won't be filled with the wget download status. This will make debugging failed testcases easier.

Since I was adding command line arguments I also added `--help` option. 

## Question for Reviewers
Some of the script have `set -ex` and some have it commented out. Should we default to the same behavior for all the scripts?

## Tests Conducted: 
Tested scripts by hand.