### PR TITLE
Contrib data script's wget verbosity fix

### DIFF
--- a/contrib/get_aerosol_climo.sh
+++ b/contrib/get_aerosol_climo.sh
@@ -10,7 +10,7 @@ print_help() {
     echo "    --help           Show this help message and exit."
 }
 
-verbose="-nv"
+verbose="-q"
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in

--- a/contrib/get_all_static_data.sh
+++ b/contrib/get_all_static_data.sh
@@ -10,7 +10,7 @@ print_help() {
     echo "    --help           Show this help message and exit."
 }
 
-verbose="-nv"
+verbose="-q"
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in

--- a/contrib/get_mg_inccn_data.sh
+++ b/contrib/get_mg_inccn_data.sh
@@ -10,7 +10,7 @@ print_help() {
     echo "    --help           Show this help message and exit."
 }
 
-verbose="-nv"
+verbose="-q"
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in

--- a/contrib/get_thompson_tables.sh
+++ b/contrib/get_thompson_tables.sh
@@ -10,7 +10,7 @@ print_help() {
     echo "    --help           Show this help message and exit."
 }
 
-verbose="-nv"
+verbose="-q"
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in


### PR DESCRIPTION
DESCRIPTION OF CHANGES: CI after PR #526 is still producing too much output. This must be a Github CI only thing since I can't replicate the behavior locally. Switching the default to `-q` (no output) from `-nv` for `wget` to see if that fixes things.

CI OUTPUT:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/24689450-56bd-484a-8ef1-296c5f7c61fc">
