### PR TITLE
Fix area logic in SCM

### DIFF
--- a/scm/src/scm_input.F90
+++ b/scm/src/scm_input.F90
@@ -1882,6 +1882,7 @@ subroutine get_case_init_DEPHY(scm_state, scm_input)
     scm_state%runtime = elapsed_sec*scm_state%runtime_mult
   end if
 
+  scm_input%input_area = input_area(active_init_time)
   scm_input%input_time = input_time
   scm_input%input_pres_surf(1) = input_pres_surf(active_init_time) !perhaps input_pres_surf should only be equal to input_force_pres_surf?
   scm_input%input_pres = input_pres(:,active_init_time)
@@ -2067,7 +2068,6 @@ subroutine get_case_init_DEPHY(scm_state, scm_input)
 
   if (trim(input_surfaceForcingLSM) == "lsm") then
     scm_input%input_ozone = input_ozone(:,active_init_time)
-    scm_input%input_area = input_area(active_init_time)
 
     scm_input%input_stddev   = input_stddev(active_init_time)
     scm_input%input_convexity= input_convexity(active_init_time)

--- a/scm/src/scm_setup.F90
+++ b/scm/src/scm_setup.F90
@@ -43,7 +43,9 @@ subroutine set_state(scm_input, scm_reference, scm_state)
     scm_state%lat(i) = scm_input%input_lat*deg_to_rad_const
   end do
 
-
+  do i=1, scm_state%n_cols
+    scm_state%area(i) = scm_input%input_area
+  end do
 
   !> - \todo When patching in a reference sounding, need to handle the case when the reference sounding is too short; patch_in_ref
   !! checks for the case, but as of now, it just extrapolates where it needs to and returns an error code; error should be handled
@@ -160,7 +162,6 @@ subroutine set_state(scm_input, scm_reference, scm_state)
         scm_state%state_T(i,:,1) = scm_input%input_temp(:)
         scm_state%state_tracer(i,:,scm_state%water_vapor_index,1)=scm_input%input_qt
         scm_state%state_tracer(i,:,scm_state%ozone_index,1)=scm_input%input_ozone
-        scm_state%area(i) = scm_input%input_area
 
         if (scm_input%input_pres_i(1).GT. 0.0) then ! pressure are read in, overwrite values
            scm_state%pres_i(i,:)=scm_input%input_pres_i

--- a/scm/src/scm_setup.F90
+++ b/scm/src/scm_setup.F90
@@ -44,7 +44,9 @@ subroutine set_state(scm_input, scm_reference, scm_state)
   end do
 
   do i=1, scm_state%n_cols
-    scm_state%area(i) = scm_input%input_area
+    if (scm_state%area(i) == 0) then
+      scm_state%area(i) = scm_input%input_area
+    end if
   end do
 
   !> - \todo When patching in a reference sounding, need to handle the case when the reference sounding is too short; patch_in_ref


### PR DESCRIPTION
1. Correctly assign area from the DEPHY forcing file. -> pulled out of the "if surfaceForcingLSM = lsm" statement since some canned cases have "surface_forcing_lsm = none".

2. Allow column_area to override scm_state%area if it is defined in the case_confil nml. When not defined in the case_config, scm_state%area is zero. In this case, use the default case area from the DEPHY forcing file.

@grantfirl @dustinswales Should there also be logic if area is not present in DEPHY file and not in the nml? (probably) Should there be some logging added to write what area is being used? LMK and I can add.

#540 