### PR TITLE
warning fixes: Github Actions Updates

### DIFF
--- a/.github/workflows/ci_build_scm_ubuntu.yml
+++ b/.github/workflows/ci_build_scm_ubuntu.yml
@@ -1,4 +1,4 @@
-name: CI test to build the CCPP-SCM on ubuntu v22.04
+name: build the CCPP-SCM on latest Ubuntu runner
 
 on: [pull_request,workflow_dispatch]
 
@@ -6,12 +6,12 @@ jobs:
   build_scm:
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        fortran-compiler: [gfortran-10, gfortran-11, gfortran-12]
+        fortran-compiler: [gfortran-12, gfortran-14]
         build-type:       [Release, Debug]
-        py-version:       [3.7.13, 3.9.12]
+        py-version:       [3.11.7, '3.x']
 
     # Environmental variables
     env:
@@ -73,7 +73,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /home/runner/bacio
-        key: cache-bacio-fortran-${{matrix.fortran-compiler}}-key
+        key: cache-bacio-fortran-${{matrix.fortran-compiler}}-${{matrix.build-type}}-${{matrix.py-version}}-key
 
     - name: Install bacio library v2.4.1
       if: steps.cache-bacio-fortran.outputs.cache-hit != 'true'
@@ -90,7 +90,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /home/runner/NCEPLIBS-sp
-        key: cache-sp-fortran-${{matrix.fortran-compiler}}-key
+        key: cache-sp-fortran-${{matrix.fortran-compiler}}-${{matrix.build-type}}-${{matrix.py-version}}-key
 
     - name: Install SP-library v2.3.3
       if: steps.cache-sp-fortran.outputs.cache-hit != 'true'
@@ -107,7 +107,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /home/runner/myw3emc
-        key: cache-w3emc-fortran-${{matrix.fortran-compiler}}-key
+        key: cache-w3emc-fortran-${{matrix.fortran-compiler}}-${{matrix.build-type}}-${{matrix.py-version}}-key
 
     - name: Install w3emc library v2.9.2
       if: steps.cache-w3emc-fortran.outputs.cache-hit != 'true'
@@ -129,7 +129,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /home/runner/netcdf-fortran
-        key: cache-netcdf-fortran-${{matrix.fortran-compiler}}-key
+        key: cache-netcdf-fortran-${{matrix.fortran-compiler}}-${{matrix.build-type}}-${{matrix.py-version}}-key
 
     - name: Install NetCDF Fortran library
       if: steps.cache-netcdf-fortran.outputs.cache-hit != 'true'

--- a/.github/workflows/ci_build_scm_ubuntu_nvidia.yml
+++ b/.github/workflows/ci_build_scm_ubuntu_nvidia.yml
@@ -1,4 +1,4 @@
-name: CI test to build the CCPP-SCM on ubuntu v22.04
+name: build the CCPP-SCM with Nvidia
 
 on: [pull_request,workflow_dispatch]
 
@@ -6,14 +6,14 @@ jobs:
 
   build_scm:
     # The type of runner that the job will run on
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         fortran-compiler: [nvfortran]
-        build-type:       [Release]#, Debug]
-        enable-gpu-acc:   [False, True]
-        py-version:       [3.7.13, 3.9.12]
+        build-type:       [Release] #, Debug]
+        enable-gpu-acc:   [False] #, True] # GPUs aren't available for testing
+        py-version:       [3.11.7]
 
     # Environmental variables
     env:
@@ -74,13 +74,13 @@ jobs:
       with:
         python-version: ${{matrix.py-version}}
 
-    - name: Add conda to system path
-      run: |
-        echo $CONDA/bin >> $GITHUB_PATH
+    # - name: Add conda to system path
+    #   run: |
+    #     echo $CONDA/bin >> $GITHUB_PATH
 
-    - name: Install NetCDF Python libraries
-      run: |
-        conda install --yes -c conda-forge h5py>=3.4 netCDF4 f90nml
+    # - name: Install NetCDF Python libraries
+    #   run: |
+    #     conda install --yes -c conda-forge h5py>=3.4 netCDF4 f90nml
 
     #######################################################################################
     # Install Nvidia.
@@ -90,34 +90,40 @@ jobs:
       env:
         NVCOMPILERS: /home/runner/hpc_sdk
         NVARCH: Linux_x86_64
+        NVYEAR: 2025
+        NVVERSION: 25.1
+        CUDA_VERSION: 12.6
+        NVVERSION_PACKED: 251 # Manually take NVVERSION and remove . because funcationality not in actions
         NVHPC_SILENT: true
         NVHPC_INSTALL_DIR: /home/runner/hpc_sdk
         NVHPC_INSTALL_TYPE: network
         NVHPC_INSTALL_LOCAL_DIR: /home/runner/hpc_sdk
       run: |
         mkdir /home/runner/hpc_sdk && cd /home/runner/hpc_sdk
-        wget -q https://developer.download.nvidia.com/hpc-sdk/24.1/nvhpc_2024_241_Linux_x86_64_cuda_12.3.tar.gz
-        tar xpzf nvhpc_2024_241_Linux_x86_64_cuda_12.3.tar.gz
-        nvhpc_2024_241_Linux_x86_64_cuda_12.3/install
-        export PATH=${PATH}:${NVCOMPILERS}/${NVARCH}/24.1/compilers/bin
-        export MANPATH=${MANPATH}:${NVCOMPILERS}/${NVARCH}/24.1/compilers/man
+        wget -q https://developer.download.nvidia.com/hpc-sdk/${NVVERSION}/nvhpc_${NVYEAR}_${NVVERSION_PACKED}_Linux_x86_64_cuda_${CUDA_VERSION}.tar.gz
+        tar xpzf nvhpc_${NVYEAR}_${NVVERSION_PACKED}_Linux_x86_64_cuda_${CUDA_VERSION}.tar.gz
+        ls
+        nvhpc_${NVYEAR}_${NVVERSION_PACKED}_Linux_x86_64_cuda_${CUDA_VERSION}/install
+        export PATH=${PATH}:${NVCOMPILERS}/${NVARCH}/${NVVERSION}/compilers/bin
+        export MANPATH=${MANPATH}:${NVCOMPILERS}/${NVARCH}/${NVVERSION}/compilers/man
         echo "The nvfortran installed is:"
         nvfortran --version
         echo "The path to nvfortran is:"
         command -v nvfortran
         echo "Removing tarball"
-        rm nvhpc_2024_241_Linux_x86_64_cuda_12.3.tar.gz
-
-    - name: Set environment for Nvidia compiler.
-      run: |
-        echo "CC=/home/runner/hpc_sdk/Linux_x86_64/24.1/compilers/bin/nvc" >> $GITHUB_ENV
-        echo "FC=/home/runner/hpc_sdk/Linux_x86_64/24.1/compilers/bin/nvfortran" >> $GITHUB_ENV
-        echo "CMAKE_C_COMPILER=/home/runner/hpc_sdk/Linux_x86_64/24.1/compilers/bin/nvc" >> $GITHUB_ENV
-        echo "CMAKE_Fortran_COMPILER=/home/runner/hpc_sdk/Linux_x86_64/24.1/compilers/bin/nvfortran" >> $GITHUB_ENV
+        rm nvhpc_${NVYEAR}_${NVVERSION_PACKED}_Linux_x86_64_cuda_${CUDA_VERSION}.tar.gz
+        echo "CC=/home/runner/hpc_sdk/Linux_x86_64/${NVVERSION}/compilers/bin/nvc" >> $GITHUB_ENV
+        echo "FC=/home/runner/hpc_sdk/Linux_x86_64/${NVVERSION}/compilers/bin/nvfortran" >> $GITHUB_ENV
+        echo "CMAKE_C_COMPILER=/home/runner/hpc_sdk/Linux_x86_64/${NVVERSION}/compilers/bin/nvc" >> $GITHUB_ENV
+        echo "CMAKE_Fortran_COMPILER=/home/runner/hpc_sdk/Linux_x86_64/${NVVERSION}/compilers/bin/nvfortran" >> $GITHUB_ENV
 
     #######################################################################################
     # Install FORTRAN dependencies
     #######################################################################################
+
+    - name: Check space (pre dependency install)
+      run: |
+        df -h
 
     - name: Install Curl and zlib
       run: |
@@ -142,6 +148,8 @@ jobs:
         ./configure --prefix=${HDF5_ROOT}
         make -j
         make install
+        cd ..
+        rm -rf hdf5-hdf5-1_14_1-2 hdf5-1_14_1-2.tar.gz
 
     - name: Setup HDF5 Paths
       run: |
@@ -175,6 +183,8 @@ jobs:
       run: |
         cd ${HOME}/openmpi-4.1.6
         sudo make install -j
+        cd ..
+        rm -rf openmpi-4.1.6 openmpi-4.1.6.tar.gz
 
     - name: Setup OpenMPI Paths
       run: |
@@ -213,6 +223,8 @@ jobs:
         CPPFLAGS="-I/home/runner/hdf5/include" LDFLAGS="-L/home/runner/hdf5/lib" ./configure --prefix=${NETCDF}
         make
         make install
+        cd ..
+        rm -rf netcdf-c-4.7.4 v4.7.4.tar.gz
 
     - name: Install NetCDF Fortran library
       if: steps.cache-netcdf.outputs.cache-hit != 'true'
@@ -223,6 +235,8 @@ jobs:
         FCFLAGS="-fPIC" FFLAGS="-fPIC" CPPFLAGS="-I/home/runner/hdf5/include -I/home/runner/netcdf/include" LDFLAGS="-L/home/runner/hdf5/lib -L/home/runner/netcdf/lib" ./configure --prefix=${NETCDF}
         make
         make install
+        cd ..
+        rm -rf netcdf-fortran-4.6.1 v4.6.1.tar.gz
 
     - name: Cache bacio library v2.4.1
       id: cache-bacio-fortran
@@ -240,6 +254,8 @@ jobs:
         make -j
         make install
         echo "bacio_DIR=/home/runner/bacio/lib/cmake/bacio" >> $GITHUB_ENV
+        cd ../../
+        rm -rf bacio
 
     - name: Cache SP-library v2.3.3
       id: cache-sp-fortran
@@ -257,6 +273,8 @@ jobs:
         make -j
         make install
         echo "sp_DIR=/home/runner/NCEPLIBS-sp/lib/cmake/sp" >> $GITHUB_ENV
+        cd ../../
+        rm -rf NCEPLIBS-sp
 
     - name: Cache w3emc library v2.9.2
       id: cache-w3emc-fortran
@@ -274,6 +292,12 @@ jobs:
         make -j
         make install
         echo "w3emc_DIR=/home/runner/myw3emc/lib/cmake/w3emc" >> $GITHUB_ENV
+        cd ../../
+        rm -rf NCEPLIBS-w3emc
+
+    - name: Check space (pre SCM build)
+      run: |
+        df -h
 
     #######################################################################################
     # Build and run SCM regression tests (ccpp-scm/test/rt_test_cases.py)
@@ -290,16 +314,20 @@ jobs:
         cd ${SCM_ROOT}/scm/bin
         make -j
 
-    - name: Download data for SCM
-      if: contains(matrix.enable-gpu-acc, 'False')
+    - name: Check space (post SCM build)
       run: |
-        cd ${SCM_ROOT}
-        ./contrib/get_all_static_data.sh
-        ./contrib/get_thompson_tables.sh
-        ./contrib/get_aerosol_climo.sh
+        df -h
 
-    - name: Run SCM RTs (w/o GPU)
-      if: contains(matrix.enable-gpu-acc, 'False')
-      run: |
-        cd ${SCM_ROOT}/scm/bin
-        ./run_scm.py --file /home/runner/work/ccpp-scm/ccpp-scm/test/rt_test_cases.py --runtime_mult 0.1 -v
+    # - name: Download data for SCM
+    #   if: contains(matrix.enable-gpu-acc, 'False')
+    #   run: |
+    #     cd ${SCM_ROOT}
+    #     ./contrib/get_all_static_data.sh
+    #     ./contrib/get_thompson_tables.sh
+    #     ./contrib/get_aerosol_climo.sh
+
+    # - name: Run SCM RTs (w/o GPU)
+    #   if: contains(matrix.enable-gpu-acc, 'False')
+    #   run: |
+    #     cd ${SCM_ROOT}/scm/bin
+    #     ./run_scm.py --file /home/runner/work/ccpp-scm/ccpp-scm/test/rt_test_cases.py --runtime_mult 0.1 -v

--- a/.github/workflows/ci_run_scm_DEPHY.yml
+++ b/.github/workflows/ci_run_scm_DEPHY.yml
@@ -1,4 +1,4 @@
-name: CI test to run the SCM with DEPHY v1 data
+name: run the SCM with DEPHY v1 data
 
 on: [pull_request,workflow_dispatch]
 
@@ -6,12 +6,12 @@ jobs:
   run-scm-DEPHY:
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         fortran-compiler: [gfortran-12]
         build-type:       [Release, Debug]
-        py-version:       [3.7.13]
+        py-version:       [3.11.7]
 
     # Environmental variables
     env:
@@ -72,7 +72,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /home/runner/bacio
-        key: cache-bacio-fortran-${{matrix.fortran-compiler}}-key
+        key: cache-bacio-fortran-${{matrix.fortran-compiler}}-${{matrix.build-type}}-key
 
     - name: Install bacio library v2.4.1
       if: steps.cache-bacio-fortran.outputs.cache-hit != 'true'
@@ -89,7 +89,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /home/runner/NCEPLIBS-sp
-        key: cache-sp-fortran-${{matrix.fortran-compiler}}-key
+        key: cache-sp-fortran-${{matrix.fortran-compiler}}-${{matrix.build-type}}-key
 
     - name: Install SP-library v2.3.3
       if: steps.cache-sp-fortran.outputs.cache-hit != 'true'
@@ -106,7 +106,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /home/runner/myw3emc
-        key: cache-w3emc-fortran-${{matrix.fortran-compiler}}-key
+        key: cache-w3emc-fortran-${{matrix.fortran-compiler}}-${{matrix.build-type}}-key
 
     - name: Install w3emc library v2.9.2
       if: steps.cache-w3emc-fortran.outputs.cache-hit != 'true'
@@ -126,7 +126,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /home/runner/netcdf-fortran
-        key: cache-netcdf-fortran-${{matrix.fortran-compiler}}-key
+        key: cache-netcdf-fortran-${{matrix.fortran-compiler}}-${{matrix.build-type}}-key
 
     - name: Install NetCDF Fortran library
       if: steps.cache-netcdf-fortran.outputs.cache-hit != 'true'
@@ -151,7 +151,7 @@ jobs:
         cd ${SCM_ROOT}
         ./contrib/get_all_static_data.sh
         ./contrib/get_thompson_tables.sh
-    
+
     - name: Configure build with CMake (Release)
       if: contains(matrix.build-type, 'Release')
       run: |

--- a/.github/workflows/ci_run_scm_rts.yml
+++ b/.github/workflows/ci_run_scm_rts.yml
@@ -1,5 +1,5 @@
 
-name: CI test to build and run SCM regression tests
+name: build and run SCM regression tests
 
 on: [pull_request, workflow_dispatch]
 
@@ -7,12 +7,12 @@ jobs:
   run_scm_rts:
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         fortran-compiler: [gfortran-11]
         build-type:       [Release, Debug, SinglePrecision]
-        py-version:       [3.9.12]
+        py-version:       [3.11.7]
 
     # Environmental variables
     env:
@@ -78,7 +78,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /home/runner/bacio
-        key: cache-bacio-fortran-${{matrix.fortran-compiler}}-key
+        key: cache-bacio-fortran-${{matrix.fortran-compiler}}-${{matrix.build-type}}-key
 
     - name: Install bacio library v2.4.1
       if: steps.cache-bacio-fortran.outputs.cache-hit != 'true'
@@ -95,7 +95,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /home/runner/NCEPLIBS-sp
-        key: cache-sp-fortran-${{matrix.fortran-compiler}}-key
+        key: cache-sp-fortran-${{matrix.fortran-compiler}}-${{matrix.build-type}}-key
 
     - name: Install SP-library v2.3.3
       if: steps.cache-sp-fortran.outputs.cache-hit != 'true'
@@ -112,7 +112,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /home/runner/myw3emc
-        key: cache-w3emc-fortran-${{matrix.fortran-compiler}}-key
+        key: cache-w3emc-fortran-${{matrix.fortran-compiler}}-${{matrix.build-type}}-key
 
     - name: Install w3emc library v2.9.2
       if: steps.cache-w3emc-fortran.outputs.cache-hit != 'true'
@@ -132,7 +132,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: /home/runner/netcdf-fortran
-        key: cache-netcdf-fortran-${{matrix.fortran-compiler}}-key
+        key: cache-netcdf-fortran-${{matrix.fortran-compiler}}-${{matrix.build-type}}-key
 
     - name: Install NetCDF Fortran library
       if: steps.cache-netcdf-fortran.outputs.cache-hit != 'true'
@@ -217,7 +217,17 @@ jobs:
         cd ${SCM_ROOT}/test
         ./cmp_rt2bl.py --dir_rt ${dir_rt} --dir_bl ${dir_bl}
 
+    - name: Check if SCM RT plots exist
+      id: check_files
+      run: |
+        if [ -n "$(ls -A /home/runner/work/ccpp-scm/ccpp-scm/test/scm_rt_out 2>/dev/null)" ]; then
+          echo "files_exist=true" >> "$GITHUB_ENV"
+        else
+          echo "files_exist=false" >> "$GITHUB_ENV"
+        fi
+
     - name: Upload plots of SCM Baselines/RTs as GitHub Artifact.
+      if: env.files_exist == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: rt-plots-${{matrix.build-type}}

--- a/.github/workflows/ci_run_scm_ufs_replay.yml
+++ b/.github/workflows/ci_run_scm_ufs_replay.yml
@@ -1,4 +1,4 @@
-name: CI test to create SCM UFS-replay cases from UWM regression tests
+name: create SCM UFS-replay cases from UWM regression tests
 
 on: [pull_request,workflow_dispatch]
 
@@ -6,7 +6,7 @@ jobs:
   run_scm_ufs_replay:
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -el {0}
@@ -45,6 +45,7 @@ jobs:
         use-only-tar-bz2: true
         auto-activate-base: true
         auto-update-conda: true
+        conda-remove-defaults: "true"
 
     #######################################################################################
     # Create UFS-replay case for SCM using UWM Regression Tests
@@ -56,11 +57,11 @@ jobs:
         path: ${dir_rt_cache}
         key: ufs-rt-files
 
-    - name: Download UWM regression test output from NCAR-DTC FTP site, if not cached.
+    - name: Download UWM regression test output, if not cached.
       run: |
         if test ! -d "${dir_rt_cache}"; then
           mkdir -p ${dir_rt_cache} && cd ${dir_rt_cache}
-          wget -q ftp://ftp.rap.ucar.edu:/pub/ccpp-scm/ufs_rts_scmreplay_ci.tar
+          wget https://dtcenter.ucar.edu/ccpp/rt/ufs_rts_scmreplay_ci.tar
           tar -xvf ufs_rts_scmreplay_ci.tar
           ls ${dir_rt_cache}
         fi

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -7,7 +7,7 @@ jobs:
   build-linux:
 
     # The type of runner that the job will run on
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
 
@@ -17,10 +17,10 @@ jobs:
     - name: Initialize submodules
       run: git submodule update --init --recursive
 
-    - name: Set up Python 3.8.5
+    - name: Set up Python 3.11.7
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8.5
+        python-version: 3.11.7
 
     - name: Add conda to system path
       run: |

--- a/.github/workflows/ci_test_docker.yml
+++ b/.github/workflows/ci_test_docker.yml
@@ -1,4 +1,4 @@
-name: build_test_and_push_docker
+name: build test and push docker
 
 on: [pull_request,workflow_dispatch]
 


### PR DESCRIPTION
Changes to fix warnings from Github CI runs. 

- Change all to latest Ubuntu runner option, 20.04 is being deprecated.

- Simplifying test names and renaming files for move to latest Ubuntu runner

- Testing with Spack Python versions 3.11.7 and latest

- Updating NVIDIA HPC SDK release, only building and not using Conda to reduce space

- Adding more unique cache names

- Fixes warning if plots aren't created

- ftp site was taken down, moving location of replay