### PR TITLE
Try spack-stack 1.9.0 on Hera for unifying python environment

### DIFF
--- a/scm/etc/modules/hera_gnu_spack_stack_1.9.1.lua
+++ b/scm/etc/modules/hera_gnu_spack_stack_1.9.1.lua
@@ -1,0 +1,29 @@
+help([[
+This module loads libraries for building the CCPP Single-Column Model on
+the NOAA RDHPC machine Hera using GNU 13.2
+]])
+
+whatis([===[Loads libraries needed for building the CCPP SCM on Hera with GNU compilers ]===])
+
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.1/envs/ue-gcc-13.2.0/install/modulefiles/Core")
+
+load("stack-gcc/13.2.0")
+load("stack-openmpi/4.1.6")
+load("stack-python/3.11.7")
+load("py-f90nml")
+load("py-netcdf4")
+load("cmake/3.28.1")
+
+load("netcdf-c/4.9.2")
+load("netcdf-fortran/4.6.1")
+load("bacio/2.4.1")
+load("sp/2.5.0")
+load("w3emc/2.10.0")
+load("esmf")
+
+setenv("CMAKE_C_COMPILER","mpicc")
+setenv("CMAKE_CXX_COMPILER","mpicxx")
+setenv("CMAKE_Fortran_COMPILER","mpif90")
+setenv("CMAKE_Platform","hera.gnu")
+
+execute{cmd="source /scratch1/BMC/gmtb/ccpp-scm-software/spack-stack-1.9.1/bin/activate", modeA={"load"}}

--- a/scm/etc/modules/hera_intel_spack_stack_1.9.0.lua
+++ b/scm/etc/modules/hera_intel_spack_stack_1.9.0.lua
@@ -1,0 +1,27 @@
+help([[
+This module loads libraries for building the CCPP Single-Column Model on
+the NOAA RDHPC machine Hera using Intel-2021.5.0
+]])
+
+whatis([===[Loads libraries needed for building the CCPP SCM on Hera with Intel compilers ]===])
+
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.0/envs/ue-oneapi-2024.2.1/install/modulefiles/Core/")
+
+load("stack-oneapi/2024.2.1")
+load("stack-intel-oneapi-mpi/2021.13")
+load("stack-python/3.11.7")
+load("py-f90nml")
+load("py-netcdf4")
+load("cmake/3.28.1")
+
+load("netcdf-c/4.9.2")
+load("netcdf-fortran/4.6.1")
+load("bacio/2.4.1")
+load("sp/2.5.0")
+load("w3emc/2.10.0")
+load("esmf")
+
+setenv("CMAKE_C_COMPILER","mpiicc")
+setenv("CMAKE_CXX_COMPILER","mpiicpc")
+setenv("CMAKE_Fortran_COMPILER","mpiifort")
+setenv("CMAKE_Platform","hera.intel")

--- a/scm/etc/modules/hera_intel_spack_stack_1.9.0.lua
+++ b/scm/etc/modules/hera_intel_spack_stack_1.9.0.lua
@@ -25,3 +25,5 @@ setenv("CMAKE_C_COMPILER","mpiicc")
 setenv("CMAKE_CXX_COMPILER","mpiicpc")
 setenv("CMAKE_Fortran_COMPILER","mpiifort")
 setenv("CMAKE_Platform","hera.intel")
+
+execute{cmd="source /scratch1/BMC/gmtb/ccpp-scm-software/spack-stack-1.9.0/bin/activate", modeA={"load"}}

--- a/scm/etc/modules/hera_intel_spack_stack_1.9.1.lua
+++ b/scm/etc/modules/hera_intel_spack_stack_1.9.1.lua
@@ -5,7 +5,7 @@ the NOAA RDHPC machine Hera using Intel-2021.5.0
 
 whatis([===[Loads libraries needed for building the CCPP SCM on Hera with Intel compilers ]===])
 
-prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.0/envs/ue-oneapi-2024.2.1/install/modulefiles/Core/")
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/modulefiles/Core/")
 
 load("stack-oneapi/2024.2.1")
 load("stack-intel-oneapi-mpi/2021.13")
@@ -26,4 +26,4 @@ setenv("CMAKE_CXX_COMPILER","mpiicpc")
 setenv("CMAKE_Fortran_COMPILER","mpiifort")
 setenv("CMAKE_Platform","hera.intel")
 
-execute{cmd="source /scratch1/BMC/gmtb/ccpp-scm-software/spack-stack-1.9.0/bin/activate", modeA={"load"}}
+execute{cmd="source /scratch1/BMC/gmtb/ccpp-scm-software/spack-stack-1.9.1/bin/activate", modeA={"load"}}


### PR DESCRIPTION
I created a new modulefile to use an experimental installation of spack-stack 1.9.0 from Ratko Vasic on Hera.

To use:
 - cd to the top level of ccpp-scm
 - module use scm/etc/modules
 - module load hera_intel_spack_stack_1.9.0

This load the spack-stack installation of python, although following https://spack-stack.readthedocs.io/en/1.6.0/MaintainersSection.html, I've created a new virtual environment using the spack-stack 1.9.0 python that should have every python package needed by any and all python scripts in the CCPP SCM repo. The environment is located in /scratch1/BMC/gmtb/ccpp-scm-software/spack-stack-1.9.0. To activate this virtual environment:

 - source /scratch1/BMC/gmtb/ccpp-scm-software/spack-stack-1.9.0/bin/activate