### PR TITLE
Introducing ATOMIC test case

### DIFF
--- a/ccpp/suites/suite_SCM_GFS_v17_p8_ugwpv1_no_nsst.xml
+++ b/ccpp/suites/suite_SCM_GFS_v17_p8_ugwpv1_no_nsst.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suite name="SCM_GFS_v17_p8_ugwpv1_no_nsst" version="1">
+  <!-- <init></init> -->
+  <group name="time_vary">
+    <subcycle loop="1">
+      <scheme>GFS_time_vary_pre</scheme>
+      <scheme>GFS_rrtmg_setup</scheme>
+      <scheme>GFS_rad_time_vary</scheme>
+      <scheme>GFS_phys_time_vary</scheme>
+    </subcycle>
+  </group>
+  <group name="radiation">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>GFS_rrtmg_pre</scheme>
+      <scheme>GFS_radiation_surface</scheme>
+      <scheme>rad_sw_pre</scheme>
+      <scheme>rrtmg_sw</scheme>
+      <scheme>rrtmg_sw_post</scheme>
+      <scheme>rrtmg_lw</scheme>
+      <scheme>rrtmg_lw_post</scheme>
+      <scheme>GFS_rrtmg_post</scheme>
+    </subcycle>
+  </group>
+  <group name="physics">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_phys_reset</scheme>
+      <scheme>GFS_suite_stateout_reset</scheme>
+      <scheme>get_prs_fv3</scheme>
+      <scheme>GFS_suite_interstitial_1</scheme>
+      <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>GFS_surface_composites_pre</scheme>
+      <scheme>dcyc2t3</scheme>
+      <scheme>GFS_surface_composites_inter</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
+    </subcycle>
+    <!-- Surface iteration loop -->
+    <subcycle loop="2">
+      <scheme>sfc_diff</scheme>
+      <scheme>GFS_surface_loop_control_part1</scheme>
+      <scheme>sfc_ocean</scheme>
+      <scheme>noahmpdrv</scheme>
+      <scheme>sfc_sice</scheme>
+      <scheme>GFS_surface_loop_control_part2</scheme>
+    </subcycle>
+    <!-- End of surface iteration loop -->
+    <subcycle loop="1">
+      <scheme>GFS_surface_composites_post</scheme>
+      <scheme>sfc_diag</scheme>
+      <scheme>sfc_diag_post</scheme>
+      <scheme>GFS_surface_generic_post</scheme>
+      <scheme>GFS_PBL_generic_pre</scheme>
+      <scheme>satmedmfvdifq</scheme>
+      <scheme>GFS_PBL_generic_post</scheme>
+      <scheme>GFS_GWD_generic_pre</scheme>
+      <scheme>ugwpv1_gsldrag</scheme>
+      <scheme>ugwpv1_gsldrag_post</scheme>
+      <scheme>GFS_GWD_generic_post</scheme>
+      <scheme>GFS_suite_stateout_update</scheme>
+      <scheme>GFS_photochemistry</scheme>
+      <scheme>get_phi_fv3</scheme>
+      <scheme>GFS_suite_interstitial_3</scheme>
+      <scheme>GFS_DCNV_generic_pre</scheme>
+      <scheme>samfdeepcnv</scheme>
+      <scheme>GFS_DCNV_generic_post</scheme>
+      <scheme>GFS_SCNV_generic_pre</scheme>
+      <scheme>samfshalcnv</scheme>
+      <scheme>GFS_SCNV_generic_post</scheme>
+      <scheme>GFS_suite_interstitial_4</scheme>
+      <scheme>cnvc90</scheme>
+      <scheme>GFS_MP_generic_pre</scheme>
+      <scheme>mp_thompson_pre</scheme>
+      </subcycle>
+      <subcycle loop="1">
+        <scheme>mp_thompson</scheme>
+      </subcycle>
+        <subcycle loop="1">
+        <scheme>mp_thompson_post</scheme>
+        <scheme>GFS_MP_generic_post</scheme>
+        <scheme>maximum_hourly_diagnostics</scheme>
+        <scheme>GFS_physics_post</scheme>
+      </subcycle>
+    </group>
+  <!-- <finalize></finalize> -->
+</suite>

--- a/ccpp/suites/suite_SCM_GFS_v17_p8_ugwpv1_no_nsst_ps.xml
+++ b/ccpp/suites/suite_SCM_GFS_v17_p8_ugwpv1_no_nsst_ps.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suite name="SCM_GFS_v17_p8_ugwpv1_no_nsst_ps" version="1">
+  <!-- <init></init> -->
+  <group name="time_vary">
+    <subcycle loop="1">
+      <scheme>GFS_time_vary_pre</scheme>
+      <scheme>GFS_rrtmg_setup</scheme>
+      <scheme>GFS_rad_time_vary</scheme>
+      <scheme>GFS_phys_time_vary</scheme>
+    </subcycle>
+  </group>
+  <group name="radiation">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>GFS_rrtmg_pre</scheme>
+      <scheme>GFS_radiation_surface</scheme>
+      <scheme>rad_sw_pre</scheme>
+      <scheme>rrtmg_sw</scheme>
+      <scheme>rrtmg_sw_post</scheme>
+      <scheme>rrtmg_lw</scheme>
+      <scheme>rrtmg_lw_post</scheme>
+      <scheme>GFS_rrtmg_post</scheme>
+    </subcycle>
+  </group>
+  <group name="physics">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_phys_reset</scheme>
+      <scheme>GFS_suite_stateout_reset</scheme>
+      <scheme>get_prs_fv3</scheme>
+      <scheme>GFS_suite_interstitial_1</scheme>
+      <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>scm_sfc_flux_spec</scheme>
+      <scheme>dcyc2t3</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
+      <scheme>GFS_PBL_generic_pre</scheme>
+      <scheme>satmedmfvdifq</scheme>
+      <scheme>GFS_PBL_generic_post</scheme>
+      <scheme>GFS_GWD_generic_pre</scheme>
+      <scheme>ugwpv1_gsldrag</scheme>
+      <scheme>ugwpv1_gsldrag_post</scheme>
+      <scheme>GFS_GWD_generic_post</scheme>
+      <scheme>GFS_suite_stateout_update</scheme>
+      <scheme>GFS_photochemistry</scheme>
+      <scheme>get_phi_fv3</scheme>
+      <scheme>GFS_suite_interstitial_3</scheme>
+      <scheme>GFS_DCNV_generic_pre</scheme>
+      <scheme>samfdeepcnv</scheme>
+      <scheme>GFS_DCNV_generic_post</scheme>
+      <scheme>GFS_SCNV_generic_pre</scheme>
+      <scheme>samfshalcnv</scheme>
+      <scheme>GFS_SCNV_generic_post</scheme>
+      <scheme>GFS_suite_interstitial_4</scheme>
+      <scheme>cnvc90</scheme>
+      <scheme>GFS_MP_generic_pre</scheme>
+      <scheme>mp_thompson_pre</scheme>
+      </subcycle>
+      <subcycle loop="1">
+        <scheme>mp_thompson</scheme>
+      </subcycle>
+        <subcycle loop="1">
+        <scheme>mp_thompson_post</scheme>
+        <scheme>GFS_MP_generic_post</scheme>
+        <scheme>maximum_hourly_diagnostics</scheme>
+        <scheme>GFS_physics_post</scheme>
+      </subcycle>
+    </group>
+  <!-- <finalize></finalize> -->
+</suite>

--- a/ccpp/suites/suite_SCM_RRFS_v1beta_no_nsst.xml
+++ b/ccpp/suites/suite_SCM_RRFS_v1beta_no_nsst.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suite name="SCM_RRFS_v1beta_no_nsst" version="1">
+  <!-- <init></init> -->
+  <group name="time_vary">
+    <subcycle loop="1">
+      <scheme>GFS_time_vary_pre</scheme>
+      <scheme>GFS_rrtmg_setup</scheme>
+      <scheme>GFS_rad_time_vary</scheme>
+      <scheme>GFS_phys_time_vary</scheme>
+    </subcycle>
+  </group>
+  <group name="radiation">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>sgscloud_radpre</scheme>
+      <scheme>GFS_rrtmg_pre</scheme>
+      <scheme>GFS_radiation_surface</scheme>
+      <scheme>rad_sw_pre</scheme>
+      <scheme>rrtmg_sw</scheme>
+      <scheme>rrtmg_sw_post</scheme>
+      <scheme>rrtmg_lw</scheme>
+      <scheme>sgscloud_radpost</scheme>
+      <scheme>rrtmg_lw_post</scheme>
+      <scheme>GFS_rrtmg_post</scheme>
+    </subcycle>
+  </group>
+  <group name="physics">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_phys_reset</scheme>
+      <scheme>GFS_suite_stateout_reset</scheme>
+      <scheme>get_prs_fv3</scheme>
+      <scheme>GFS_suite_interstitial_1</scheme>
+      <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>GFS_surface_composites_pre</scheme>
+      <scheme>dcyc2t3</scheme>
+      <scheme>GFS_surface_composites_inter</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
+    </subcycle>
+    <!-- Surface iteration loop -->
+    <subcycle loop="2">
+      <scheme>mynnsfc_wrapper</scheme>
+      <scheme>GFS_surface_loop_control_part1</scheme>
+      <scheme>sfc_ocean</scheme>
+      <scheme>noahmpdrv</scheme>
+      <scheme>sfc_sice</scheme>
+      <scheme>GFS_surface_loop_control_part2</scheme>
+    </subcycle>
+    <!-- End of surface iteration loop -->
+    <subcycle loop="1">
+      <scheme>GFS_surface_composites_post</scheme>
+      <scheme>sfc_diag</scheme>
+      <scheme>sfc_diag_post</scheme>
+      <scheme>GFS_surface_generic_post</scheme>
+      <scheme>mynnedmf_wrapper</scheme>
+      <scheme>GFS_GWD_generic_pre</scheme>
+      <scheme>cires_ugwp</scheme>
+      <scheme>cires_ugwp_post</scheme>
+      <scheme>GFS_GWD_generic_post</scheme>
+      <scheme>GFS_suite_stateout_update</scheme>
+      <scheme>GFS_photochemistry</scheme>
+      <scheme>get_phi_fv3</scheme>
+      <scheme>GFS_suite_interstitial_3</scheme>
+      <scheme>GFS_suite_interstitial_4</scheme>
+      <scheme>GFS_MP_generic_pre</scheme>
+      <scheme>mp_thompson_pre</scheme>
+      <scheme>mp_thompson</scheme>
+      <scheme>mp_thompson_post</scheme>
+      <scheme>GFS_MP_generic_post</scheme>
+      <scheme>maximum_hourly_diagnostics</scheme>
+      <scheme>GFS_physics_post</scheme>
+    </subcycle>
+  </group>
+  <!-- <finalize></finalize> -->
+</suite>

--- a/ccpp/suites/suite_SCM_RRFS_v1beta_no_nsst_ps.xml
+++ b/ccpp/suites/suite_SCM_RRFS_v1beta_no_nsst_ps.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<suite name="SCM_RRFS_v1beta_no_nsst_ps" version="1">
+  <!-- <init></init> -->
+  <group name="time_vary">
+    <subcycle loop="1">
+      <scheme>GFS_time_vary_pre</scheme>
+      <scheme>GFS_rrtmg_setup</scheme>
+      <scheme>GFS_rad_time_vary</scheme>
+      <scheme>GFS_phys_time_vary</scheme>
+    </subcycle>
+  </group>
+  <group name="radiation">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_rad_reset</scheme>
+      <scheme>sgscloud_radpre</scheme>
+      <scheme>GFS_rrtmg_pre</scheme>
+      <scheme>GFS_radiation_surface</scheme>
+      <scheme>rad_sw_pre</scheme>
+      <scheme>rrtmg_sw</scheme>
+      <scheme>rrtmg_sw_post</scheme>
+      <scheme>rrtmg_lw</scheme>
+      <scheme>sgscloud_radpost</scheme>
+      <scheme>rrtmg_lw_post</scheme>
+      <scheme>GFS_rrtmg_post</scheme>
+    </subcycle>
+  </group>
+  <group name="physics">
+    <subcycle loop="1">
+      <scheme>GFS_suite_interstitial_phys_reset</scheme>
+      <scheme>GFS_suite_stateout_reset</scheme>
+      <scheme>get_prs_fv3</scheme>
+      <scheme>GFS_suite_interstitial_1</scheme>
+      <scheme>GFS_surface_generic_pre</scheme>
+      <scheme>scm_sfc_flux_spec</scheme>
+      <scheme>dcyc2t3</scheme>
+      <scheme>GFS_suite_interstitial_2</scheme>
+      <scheme>mynnedmf_wrapper</scheme>
+      <scheme>GFS_GWD_generic_pre</scheme>
+      <scheme>cires_ugwp</scheme>
+      <scheme>cires_ugwp_post</scheme>
+      <scheme>GFS_GWD_generic_post</scheme>
+      <scheme>GFS_suite_stateout_update</scheme>
+      <scheme>GFS_photochemistry</scheme>
+      <scheme>get_phi_fv3</scheme>
+      <scheme>GFS_suite_interstitial_3</scheme>
+      <scheme>GFS_suite_interstitial_4</scheme>
+      <scheme>GFS_MP_generic_pre</scheme>
+      <scheme>mp_thompson_pre</scheme>
+      <scheme>mp_thompson</scheme>
+      <scheme>mp_thompson_post</scheme>
+      <scheme>GFS_MP_generic_post</scheme>
+      <scheme>maximum_hourly_diagnostics</scheme>
+      <scheme>GFS_physics_post</scheme>
+    </subcycle>
+  </group>
+  <!-- <finalize></finalize> -->
+</suite>

--- a/scm/doc/TechGuide/chap_cases.rst
+++ b/scm/doc/TechGuide/chap_cases.rst
@@ -164,6 +164,13 @@ following observational field campaigns:
 -  Cold-Air Outbreaks in the Marine Boundary Layer Experiment (COMBLE) for
    March 12, 2020 mixed phased clouds in the polar marine boundary layer
 
+-  Atlantic Tradewind Ocean-Atmosphere Mesoscale Interaction Campaign (ATOMIC)
+   for January/February 2020 marine shallow convection. The ATOMIC test case
+   consists of seven 33-hour periods, each extending 16 hours before and
+   after the central times: (1) 14 UTC on Jan. 17 2020, (2) 13 UTC on Jan. 19,
+   (3) 13 UTC on Jan. 23, (4) 15 UTC on Jan. 31, (5) 13 UTC on Feb. 2,
+   (6) 04 UTC on Feb. 9, and (7) 04 UTC on Feb. 10.
+
 For the ARM SGP case, several case configuration files representing
 different time periods of the observational dataset are included,
 denoted by a trailing letter. The LASSO case may be run with different

--- a/scm/etc/case_config/atomic_Feb02T21Feb04T05.nml
+++ b/scm/etc/case_config/atomic_Feb02T21Feb04T05.nml
@@ -1,0 +1,7 @@
+&case_config
+    case_name = 'atomic_Feb02T21Feb04T05'
+    column_area = 169000000.0
+    input_type = 1
+    reference_profile_choice = 1
+    sfc_roughness_length_cm = 0.02
+/

--- a/scm/etc/case_config/atomic_Feb08T12Feb09T20.nml
+++ b/scm/etc/case_config/atomic_Feb08T12Feb09T20.nml
@@ -1,0 +1,7 @@
+&case_config
+    case_name = 'atomic_Feb08T12Feb09T20'
+    column_area = 169000000.0
+    input_type = 1
+    reference_profile_choice = 1
+    sfc_roughness_length_cm = 0.02
+/

--- a/scm/etc/case_config/atomic_Feb09T12Feb10T20.nml
+++ b/scm/etc/case_config/atomic_Feb09T12Feb10T20.nml
@@ -1,0 +1,7 @@
+&case_config
+    case_name = 'atomic_Feb09T12Feb10T20'
+    column_area = 169000000.0
+    input_type = 1
+    reference_profile_choice = 1
+    sfc_roughness_length_cm = 0.02
+/

--- a/scm/etc/case_config/atomic_Jan16T22Jan18T06.nml
+++ b/scm/etc/case_config/atomic_Jan16T22Jan18T06.nml
@@ -1,0 +1,7 @@
+&case_config
+    case_name = 'atomic_Jan16T22Jan18T06'
+    column_area = 169000000.0
+    input_type = 1
+    reference_profile_choice = 1
+    sfc_roughness_length_cm = 0.02
+/

--- a/scm/etc/case_config/atomic_Jan18T21Jan20T05.nml
+++ b/scm/etc/case_config/atomic_Jan18T21Jan20T05.nml
@@ -1,0 +1,7 @@
+&case_config
+    case_name = 'atomic_Jan18T21Jan20T05'
+    column_area = 169000000.0
+    input_type = 1
+    reference_profile_choice = 1
+    sfc_roughness_length_cm = 0.02
+/

--- a/scm/etc/case_config/atomic_Jan22T21Jan24T05.nml
+++ b/scm/etc/case_config/atomic_Jan22T21Jan24T05.nml
@@ -1,0 +1,7 @@
+&case_config
+    case_name = 'atomic_Jan22T21Jan24T05'
+    column_area = 169000000.0
+    input_type = 1
+    reference_profile_choice = 1
+    sfc_roughness_length_cm = 0.02
+/

--- a/scm/etc/case_config/atomic_Jan30T23Feb01T07.nml
+++ b/scm/etc/case_config/atomic_Jan30T23Feb01T07.nml
@@ -1,0 +1,7 @@
+&case_config
+    case_name = 'atomic_Jan30T23Feb01T07'
+    column_area = 169000000.0
+    input_type = 1
+    reference_profile_choice = 1
+    sfc_roughness_length_cm = 0.02
+/

--- a/scm/src/suite_info.py
+++ b/scm/src/suite_info.py
@@ -74,6 +74,8 @@ suite_list.append(suite('SCM_GSD_v1',            'tracers_gsd.txt',             
 suite_list.append(suite('SCM_RRFS_v1nssl',       'tracers_RRFS_v1nssl_nohail_noccn.txt', 'input_RRFS_v1nssl_nohailnoccn.nml', 600.0, 600.0 , False))
 suite_list.append(suite('SCM_csawmg',            'tracers_csawmg.txt',                   'input_csawmg.nml',                  600.0, 1800.0, False))
 suite_list.append(suite('SCM_GFS_v16_debug',     'tracers_GFS_v16.txt',                  'input_GFS_v16.nml',                 600.0, 1800.0, False))
+suite_list.append(suite('SCM_GFS_v17_p8_ugwpv1_no_nsst', 'tracers_GFS_v17_p8_ugwpv1.txt','input_GFS_v17_p8_ugwpv1.nml',       600.0, 600.0,  False))
+suite_list.append(suite('SCM_RRFS_v1beta_no_nsst',       'tracers_RRFS_v1beta.txt',      'input_RRFS_v1beta.nml',             600.0, 600.0 , False))
 
 def main():
     

--- a/test/rt_test_cases.py
+++ b/test/rt_test_cases.py
@@ -41,6 +41,9 @@ run_list = [\
             #----------------------------------------------------------------------------------------------------------------------------------------------
             # Unsupported suites (w/ supported cases)
             #----------------------------------------------------------------------------------------------------------------------------------------------
+            {"case": "atomic_Jan16T22Jan18T06", "suite": "SCM_GFS_v16_no_nsst"},                                                                          \
+            {"case": "atomic_Jan16T22Jan18T06", "suite": "SCM_GFS_v17_p8_ugwpv1_no_nsst"},                                                                \
+            {"case": "atomic_Jan16T22Jan18T06", "suite": "SCM_RRFS_v1beta_no_nsst"},                                                                      \
             {"case": "arm_sgp_summer_1997_A", "suite": "SCM_GFS_v17_p8"},                                                                                 \
             {"case": "arm_sgp_summer_1997_A", "suite": "SCM_HRRR"},                                                                                       \
             {"case": "arm_sgp_summer_1997_A", "suite": "SCM_RRFS_v1beta"},                                                                                \


### PR DESCRIPTION
This pull request introduces forcing and namelists associated with the ATOMIC field campaign. Specifically:
- **Adding DEPHY-format associated case configuration namelist files, which will be named as atomic_[period].nml, into scm/etc/case_config/.** There are seven periods in total.
- **Adding suite_SCM_GFS_v17_p8_ugwpv1_no_nsst.xml and suite_SCM_RRFS_v1beta_no_nsst.xml into ccpp/suites/.** This change allows the ATOMIC test case to be run using the 'sfc_ocean' scheme (instead of 'nsst'), which may work more properly for the oceanic field campaign cases (as suggested by [Issue #518](https://github.com/NCAR/ccpp-scm/issues/518)).  
- **Modifying suite_info.py in scm/src/ and rt_test_cases.py in test/ accordingly.** These changes enable the CCPP SCM to run the SCM_GFS_v16_no_nsst, SCM_GFS_v17_p8_ugwpv1_no_nsst, and SCM_RRFS_v1beta_no_nsst suites.