### PR TITLE
Updated version of "Move parse_tracers file from physics to host"

### DIFF
--- a/scm/src/GFS_typedefs.F90
+++ b/scm/src/GFS_typedefs.F90
@@ -29,7 +29,8 @@ module GFS_typedefs
    integer, parameter :: dfi_radar_max_intervals = 4 !< Number of radar-derived temperature tendency and/or convection suppression intervals. Do not change.
 
    real(kind=kind_phys), parameter :: limit_unspecified = 1e12 !< special constant for "namelist value was not provided" in radar-derived temperature tendency limit range
-
+   
+   integer, parameter :: no_tracer = -99
 
 !> \section arg_table_GFS_typedefs
 !! \htmlinclude GFS_typedefs.html
@@ -3334,7 +3335,6 @@ module GFS_typedefs
 !--- modules
     use physcons,         only: con_rerth, con_pi, con_p0, rhowater
     use mersenne_twister, only: random_setseed, random_number
-    use parse_tracers,    only: get_tracer_index
     use GFS_ccpp_suite_sim_pre, only: load_ccpp_suite_sim
 !
     implicit none
@@ -5307,48 +5307,48 @@ module GFS_typedefs
     Model%ntracp100        = Model%ntrac + 100
     allocate (Model%tracer_names(Model%ntrac))
     Model%tracer_names(:)  = tracer_names(:)
-    Model%ntqv             = get_tracer_index(Model%tracer_names, 'sphum',      Model%me, Model%master, Model%debug)
+    Model%ntqv             = get_tracer_index(Model%tracer_names, 'sphum')
 #ifdef MULTI_GASES
-    Model%nto              = get_tracer_index(Model%tracer_names, 'spo',        Model%me, Model%master, Model%debug)
-    Model%nto2             = get_tracer_index(Model%tracer_names, 'spo2',       Model%me, Model%master, Model%debug)
-    Model%ntoz             = get_tracer_index(Model%tracer_names, 'spo3',       Model%me, Model%master, Model%debug)
+    Model%nto              = get_tracer_index(Model%tracer_names, 'spo')
+    Model%nto2             = get_tracer_index(Model%tracer_names, 'spo2')
+    Model%ntoz             = get_tracer_index(Model%tracer_names, 'spo3')
 #else
-    Model%ntoz             = get_tracer_index(Model%tracer_names, 'o3mr',       Model%me, Model%master, Model%debug)
+    Model%ntoz             = get_tracer_index(Model%tracer_names, 'o3mr')
     if( Model%ntoz <= 0 )  &
-    Model%ntoz             =  get_tracer_index(Model%tracer_names, 'spo3',       Model%me, Model%master, Model%debug)
+    Model%ntoz             =  get_tracer_index(Model%tracer_names, 'spo3')
 #endif
-    Model%ntcw             = get_tracer_index(Model%tracer_names, 'liq_wat',    Model%me, Model%master, Model%debug)
-    Model%ntiw             = get_tracer_index(Model%tracer_names, 'ice_wat',    Model%me, Model%master, Model%debug)
-    Model%ntrw             = get_tracer_index(Model%tracer_names, 'rainwat',    Model%me, Model%master, Model%debug)
-    Model%ntsw             = get_tracer_index(Model%tracer_names, 'snowwat',    Model%me, Model%master, Model%debug)
-    Model%ntgl             = get_tracer_index(Model%tracer_names, 'graupel',    Model%me, Model%master, Model%debug)
-    Model%nthl             = get_tracer_index(Model%tracer_names, 'hailwat',    Model%me, Model%master, Model%debug)
-    Model%ntclamt          = get_tracer_index(Model%tracer_names, 'cld_amt',    Model%me, Model%master, Model%debug)
-    Model%ntlnc            = get_tracer_index(Model%tracer_names, 'water_nc',   Model%me, Model%master, Model%debug)
-    Model%ntinc            = get_tracer_index(Model%tracer_names, 'ice_nc',     Model%me, Model%master, Model%debug)
-    Model%ntrnc            = get_tracer_index(Model%tracer_names, 'rain_nc',    Model%me, Model%master, Model%debug)
-    Model%ntsnc            = get_tracer_index(Model%tracer_names, 'snow_nc',    Model%me, Model%master, Model%debug)
-    Model%ntgnc            = get_tracer_index(Model%tracer_names, 'graupel_nc', Model%me, Model%master, Model%debug)
-    Model%nthnc            = get_tracer_index(Model%tracer_names, 'hail_nc',    Model%me, Model%master, Model%debug)
-    Model%ntccn            = get_tracer_index(Model%tracer_names, 'ccn_nc',     Model%me, Model%master, Model%debug)
-    Model%ntccna           = get_tracer_index(Model%tracer_names, 'ccna_nc',    Model%me, Model%master, Model%debug)
-    Model%ntgv             = get_tracer_index(Model%tracer_names, 'graupel_vol',Model%me, Model%master, Model%debug)
-    Model%nthv             = get_tracer_index(Model%tracer_names, 'hail_vol',   Model%me, Model%master, Model%debug)
-    Model%ntrz             = get_tracer_index(Model%tracer_names, 'rain_ref',   Model%me, Model%master, Model%debug)
-    Model%ntgz             = get_tracer_index(Model%tracer_names, 'graupel_ref',Model%me, Model%master, Model%debug)
-    Model%nthz             = get_tracer_index(Model%tracer_names, 'hail_ref',   Model%me, Model%master, Model%debug)
-    Model%ntke             = get_tracer_index(Model%tracer_names, 'sgs_tke',    Model%me, Model%master, Model%debug)
-    Model%ntsigma          = get_tracer_index(Model%tracer_names, 'sigmab',     Model%me, Model%master, Model%debug)
-    Model%nqrimef          = get_tracer_index(Model%tracer_names, 'q_rimef',    Model%me, Model%master, Model%debug)
-    Model%ntwa             = get_tracer_index(Model%tracer_names, 'liq_aero',   Model%me, Model%master, Model%debug)
-    Model%ntia             = get_tracer_index(Model%tracer_names, 'ice_aero',   Model%me, Model%master, Model%debug)
+    Model%ntcw             = get_tracer_index(Model%tracer_names, 'liq_wat')
+    Model%ntiw             = get_tracer_index(Model%tracer_names, 'ice_wat')
+    Model%ntrw             = get_tracer_index(Model%tracer_names, 'rainwat')
+    Model%ntsw             = get_tracer_index(Model%tracer_names, 'snowwat')
+    Model%ntgl             = get_tracer_index(Model%tracer_names, 'graupel')
+    Model%nthl             = get_tracer_index(Model%tracer_names, 'hailwat')
+    Model%ntclamt          = get_tracer_index(Model%tracer_names, 'cld_amt')
+    Model%ntlnc            = get_tracer_index(Model%tracer_names, 'water_nc')
+    Model%ntinc            = get_tracer_index(Model%tracer_names, 'ice_nc')
+    Model%ntrnc            = get_tracer_index(Model%tracer_names, 'rain_nc')
+    Model%ntsnc            = get_tracer_index(Model%tracer_names, 'snow_nc')
+    Model%ntgnc            = get_tracer_index(Model%tracer_names, 'graupel_nc')
+    Model%nthnc            = get_tracer_index(Model%tracer_names, 'hail_nc')
+    Model%ntccn            = get_tracer_index(Model%tracer_names, 'ccn_nc')
+    Model%ntccna           = get_tracer_index(Model%tracer_names, 'ccna_nc')
+    Model%ntgv             = get_tracer_index(Model%tracer_names, 'graupel_vol')
+    Model%nthv             = get_tracer_index(Model%tracer_names, 'hail_vol')
+    Model%ntrz             = get_tracer_index(Model%tracer_names, 'rain_ref')
+    Model%ntgz             = get_tracer_index(Model%tracer_names, 'graupel_ref')
+    Model%nthz             = get_tracer_index(Model%tracer_names, 'hail_ref')
+    Model%ntke             = get_tracer_index(Model%tracer_names, 'sgs_tke')
+    Model%ntsigma          = get_tracer_index(Model%tracer_names, 'sigmab')
+    Model%nqrimef          = get_tracer_index(Model%tracer_names, 'q_rimef')
+    Model%ntwa             = get_tracer_index(Model%tracer_names, 'liq_aero')
+    Model%ntia             = get_tracer_index(Model%tracer_names, 'ice_aero')
     if (Model%cpl_fire) then
-    Model%ntfsmoke         = get_tracer_index(Model%tracer_names, 'fsmoke',   Model%me, Model%master, Model%debug)
+    Model%ntfsmoke         = get_tracer_index(Model%tracer_names, 'fsmoke')
     endif
     if (Model%rrfs_sd) then
-    Model%ntsmoke          = get_tracer_index(Model%tracer_names, 'smoke',      Model%me, Model%master, Model%debug)
-    Model%ntdust           = get_tracer_index(Model%tracer_names, 'dust',       Model%me, Model%master, Model%debug)
-    Model%ntcoarsepm       = get_tracer_index(Model%tracer_names, 'coarsepm',   Model%me, Model%master, Model%debug)
+    Model%ntsmoke          = get_tracer_index(Model%tracer_names, 'smoke')
+    Model%ntdust           = get_tracer_index(Model%tracer_names, 'dust')
+    Model%ntcoarsepm       = get_tracer_index(Model%tracer_names, 'coarsepm')
     endif
 !--- initialize parameters for atmospheric chemistry tracers
     call Model%init_chemistry(tracer_types)
@@ -5406,21 +5406,21 @@ module GFS_typedefs
     Model%dtidx = -99
 
     if(Model%ntchm>0) then
-      Model%ntdu1 = get_tracer_index(Model%tracer_names, 'dust1', Model%me, Model%master, Model%debug)
-      Model%ntdu2 = get_tracer_index(Model%tracer_names, 'dust2', Model%me, Model%master, Model%debug)
-      Model%ntdu3 = get_tracer_index(Model%tracer_names, 'dust3', Model%me, Model%master, Model%debug)
-      Model%ntdu4 = get_tracer_index(Model%tracer_names, 'dust4', Model%me, Model%master, Model%debug)
-      Model%ntdu5 = get_tracer_index(Model%tracer_names, 'dust5', Model%me, Model%master, Model%debug)
-      Model%ntss1 = get_tracer_index(Model%tracer_names, 'seas1', Model%me, Model%master, Model%debug)
-      Model%ntss2 = get_tracer_index(Model%tracer_names, 'seas2', Model%me, Model%master, Model%debug)
-      Model%ntss3 = get_tracer_index(Model%tracer_names, 'seas3', Model%me, Model%master, Model%debug)
-      Model%ntss4 = get_tracer_index(Model%tracer_names, 'seas4', Model%me, Model%master, Model%debug)
-      Model%ntss5 = get_tracer_index(Model%tracer_names, 'seas5', Model%me, Model%master, Model%debug)
-      Model%ntsu  = get_tracer_index(Model%tracer_names, 'so4',   Model%me, Model%master, Model%debug)
-      Model%ntbcb = get_tracer_index(Model%tracer_names, 'bc1',   Model%me, Model%master, Model%debug)
-      Model%ntbcl = get_tracer_index(Model%tracer_names, 'bc2',   Model%me, Model%master, Model%debug)
-      Model%ntocb = get_tracer_index(Model%tracer_names, 'oc1',   Model%me, Model%master, Model%debug)
-      Model%ntocl = get_tracer_index(Model%tracer_names, 'oc2',   Model%me, Model%master, Model%debug)
+      Model%ntdu1 = get_tracer_index(Model%tracer_names, 'dust1')
+      Model%ntdu2 = get_tracer_index(Model%tracer_names, 'dust2')
+      Model%ntdu3 = get_tracer_index(Model%tracer_names, 'dust3')
+      Model%ntdu4 = get_tracer_index(Model%tracer_names, 'dust4')
+      Model%ntdu5 = get_tracer_index(Model%tracer_names, 'dust5')
+      Model%ntss1 = get_tracer_index(Model%tracer_names, 'seas1')
+      Model%ntss2 = get_tracer_index(Model%tracer_names, 'seas2')
+      Model%ntss3 = get_tracer_index(Model%tracer_names, 'seas3')
+      Model%ntss4 = get_tracer_index(Model%tracer_names, 'seas4')
+      Model%ntss5 = get_tracer_index(Model%tracer_names, 'seas5')
+      Model%ntsu  = get_tracer_index(Model%tracer_names, 'so4')
+      Model%ntbcb = get_tracer_index(Model%tracer_names, 'bc1')
+      Model%ntbcl = get_tracer_index(Model%tracer_names, 'bc2')
+      Model%ntocb = get_tracer_index(Model%tracer_names, 'oc1')
+      Model%ntocl = get_tracer_index(Model%tracer_names, 'oc2')
     end if
 
     ! Lake & fractional grid safety checks
@@ -5484,11 +5484,11 @@ module GFS_typedefs
               ! Need better descriptions of these.
               call label_dtend_tracer(Model,100+Model%ntchm+Model%ntchs-1,'pp10','pp10 concentration','kg kg-1 s-1')
 
-              itrac=get_tracer_index(Model%tracer_names, 'DMS', Model%me, Model%master, Model%debug)
+              itrac=get_tracer_index(Model%tracer_names, 'DMS')
               if(itrac>0) then
                  call label_dtend_tracer(Model,100+itrac,'DMS','DMS concentration','kg kg-1 s-1')
               endif
-              itrac=get_tracer_index(Model%tracer_names, 'msa', Model%me, Model%master, Model%debug)
+              itrac=get_tracer_index(Model%tracer_names, 'msa')
               if(itrac>0) then
                  call label_dtend_tracer(Model,100+itrac,'msa','msa concentration','kg kg-1 s-1')
               endif
@@ -6505,8 +6505,6 @@ module GFS_typedefs
     !--- prognostic and diagnostic chemistry tracers.
     !--- Each tracer set is assumed to be contiguous.
 
-    use parse_tracers, only: NO_TRACER
-
     !--- interface variables
     class(GFS_control_type) :: Model
     integer,     intent(in) :: tracer_types(:)
@@ -6555,8 +6553,6 @@ module GFS_typedefs
 !----------------------------
   subroutine control_scavenging_initialize(Model, fscav)
 
-    use parse_tracers, only: get_tracer_index
-
     !--- interface variables
     class(GFS_control_type)      :: Model
     character(len=*), intent(in) :: fscav(:)
@@ -6590,7 +6586,7 @@ module GFS_typedefs
         if (j > 1) then
           read(fscav(i)(j+1:), *, iostat=ios) tem
           if (ios /= 0) cycle
-          n = get_tracer_index(Model%tracer_names, adjustl(fscav(i)(:j-1)), Model%me, Model%master, Model%debug) &
+          n = get_tracer_index(Model%tracer_names, adjustl(fscav(i)(:j-1))) &
               - Model%ntchs + 1
           if (n > 0) Model%fscav(n) = tem
         endif
@@ -7811,7 +7807,6 @@ module GFS_typedefs
 ! GFS_diag%create
 !----------------
   subroutine diag_create (Diag, Model)
-    use parse_tracers,    only: get_tracer_index
     class(GFS_diag_type)               :: Diag
     type(GFS_control_type), intent(in) :: Model
     integer :: IM
@@ -8412,5 +8407,32 @@ module GFS_typedefs
     endif
 
   end subroutine diag_phys_zero
+  
+  function get_tracer_index (tracer_names, name)
+
+    character(len=32), intent(in) :: tracer_names(:)
+    character(len=*),  intent(in) :: name
+    
+    !--- local variables
+    integer :: get_tracer_index
+    integer :: i
+
+    get_tracer_index = no_tracer
+
+    do i=1, size(tracer_names)
+       if (trim(name) == trim(tracer_names(i))) then
+           get_tracer_index = i
+           exit
+       endif
+    enddo
+
+    if (get_tracer_index == no_tracer) then
+      print *,'tracer with name '//trim(name)//' not found'
+    else
+      print *,'tracer FOUND:',trim(name)
+    endif
+
+    return
+  end function get_tracer_index
 
 end module GFS_typedefs

--- a/scm/src/GFS_typedefs.meta
+++ b/scm/src/GFS_typedefs.meta
@@ -10247,7 +10247,7 @@
   dependencies = hooks/machine.F,hooks/physcons.F90
   dependencies = Radiation/RRTMG/radlw_param.f,Radiation/RRTMG/radsw_param.f
   dependencies = photochem/module_ozphys.F90,photochem/module_h2ophys.F90
-  dependencies = SFC_Models/Land/Noahmp/lnd_iau_mod.F90,MP/GFDL/GFDL_parse_tracers.F90
+  dependencies = SFC_Models/Land/Noahmp/lnd_iau_mod.F90
   dependencies = Interstitials/UFS_SCM_NEPTUNE/GFS_ccpp_suite_sim_pre.F90
 
 [ccpp-arg-table]

--- a/scm/src/scm_type_defs.F90
+++ b/scm/src/scm_type_defs.F90
@@ -18,7 +18,8 @@ module scm_type_defs
                             GFS_cldprop_type,      &
                             GFS_radtend_type,      &
                             GFS_diag_type,         &
-                            GFS_init_type
+                            GFS_init_type,         &
+                            get_tracer_index
   use CCPP_typedefs,  only: GFS_interstitial_type
   use machine,        only: kind_phys
   use ccpp_types,     only: ccpp_t
@@ -1471,33 +1472,5 @@ module scm_type_defs
     end do
     
   end subroutine physics_set
-  
-  function get_tracer_index (tracer_names, name)
-
-    character(len=32), intent(in) :: tracer_names(:)
-    character(len=*),  intent(in) :: name
-    
-    !--- local variables
-    integer :: get_tracer_index
-    integer :: i
-    integer, parameter :: no_tracer = -99
-
-    get_tracer_index = no_tracer
-
-    do i=1, size(tracer_names)
-       if (trim(name) == trim(tracer_names(i))) then
-           get_tracer_index = i
-           exit
-       endif
-    enddo
-
-    if (get_tracer_index == no_tracer) then
-      print *,'tracer with name '//trim(name)//' not found'
-    else
-      print *,'tracer FOUND:',trim(name)
-    endif
-
-    return
-  end function get_tracer_index
 
 end module scm_type_defs

--- a/test/cmp_scmout.py
+++ b/test/cmp_scmout.py
@@ -41,10 +41,8 @@ def main():
     # Housekeeping
     if file_rt is not None:
         result = os.system('tar -cvf scm_out_abs.tar scm_plots/*.png')
-        result = os.system('tar -cvf /scratch1/data_untrusted/Dustin.Swales/scm_out_abs.tar scm_plots/*.png')
     else:
         result = os.system('tar -cvf scm_out_diff.tar scm_plots/*.png')
-        result = os.system('tar -cvf /scratch1/data_untrusted/Dustin.Swales/scm_out_diff.tar scm_plots/*.png')
     # end if
     result = os.system('rm -rf scm_plots/')
 #


### PR DESCRIPTION
Original description/work from @dustinswales:

This PR moves the GFDL_parse_tracers file from the physics to the host (where it belongs)
Also, is a small bugfix in a plotting script.

@grantfirl update:

- remove parse_tracers module entirely since we can use a local version of get_tracer_index() already in SCM code
- move get_tracer_index() function from scm_type_defs to GFS_typedefs to avoid circular dependency