### PR TITLE
bugfix: Github CI and Dockerfile

### DIFF
--- a/.github/workflows/ci_build_scm_ubuntu_nvidia.yml
+++ b/.github/workflows/ci_build_scm_ubuntu_nvidia.yml
@@ -1,11 +1,18 @@
 name: build the CCPP-SCM with Nvidia
 
-on: [pull_request,workflow_dispatch]
+on:
+  workflow_run:
+    workflows: ["build and run SCM regression tests"]
+    types:
+      - completed
 
 jobs:
 
   build_scm:
-    # The type of runner that the job will run on
+    # trigger only after the SCM regression tests have completed from a PR or workflow event
+    if: |
+      github.event.workflow_run.event == 'pull_request' ||
+      github.event.workflow_run.event == 'workflow_dispatch'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci_test_docker.yml
+++ b/.github/workflows/ci_test_docker.yml
@@ -1,6 +1,10 @@
 name: build test and push docker
 
-on: [pull_request,workflow_dispatch]
+on:
+  # not listing pull_request closed, since it would run when merged
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 env:
   TEST_TAG: dtcenter/ccpp-scm:test

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,30 +1,59 @@
-FROM debian:12
+FROM debian:12-slim
 LABEL maintainer="Michael Kavulich <kavulich@ucar.edu>"
 
 # arguments that can be passed in
 ARG PR_NUMBER
+# build variables
+ARG GNU_VERSION=12
+ARG VERBOSE=0
+
 
 # Set up base OS environment
 RUN apt-get -y update
 
 # Get "essential" tools and libraries
-RUN apt-get -y install build-essential \
-  && apt-get -y install cmake cmake-curses-gui curl git file gfortran-12 ksh m4 python3 tcsh time wget vim emacs-nox \
-  && apt-get -y install libnetcdf-pnetcdf-19 libnetcdff7 libnetcdf-dev libnetcdff-dev libxml2 \
-  && apt-get -y install python3-pip python3.11-venv python3-netcdf4 \
-  && apt-get -y install openmpi-bin libopenmpi-dev
+RUN apt-get update -qq && apt-get install -qq -y --no-install-recommends \
+    build-essential \
+    cmake \
+    cmake-curses-gui \
+    curl \
+    git \
+    file \
+    gfortran-$GNU_VERSION \
+    ksh \
+    m4 \
+    tcsh \
+    time \
+    wget \
+    vim \
+    emacs-nox \
+    python3 \
+    python3-pip \
+    python3.11-venv \
+    python3-netcdf4 \
+    libnetcdf-pnetcdf-19 \
+    libnetcdff7 \
+    libnetcdf-dev \
+    libnetcdff-dev \
+    libxml2 \
+    openmpi-bin \
+    libopenmpi-dev \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN ln -s /usr/bin/gfortran-$GNU_VERSION /usr/bin/gfortran
 
 # Set up python needed packages, preferred Docker method is apt-get but
 # f90nml can't be installed for debian that way
 RUN pip install f90nml --break-system-packages
 
 #Compiler environment variables
-ENV CC=/usr/bin/gcc
-ENV FC=/usr/bin/gfortran
-ENV CXX=/usr/bin/g++
-ENV F77=/usr/bin/gfortran
-ENV F90=/usr/bin/gfortran
+ENV CC=gcc
+ENV FC=gfortran
+ENV CXX=g++
+ENV F77=gfortran
+ENV F90=gfortran
 
 # Other necessary environment variables
 ENV LD_LIBRARY_PATH=/usr/lib/
@@ -47,24 +76,24 @@ WORKDIR /home
 ENV NCEPLIBS_DIR=/comsoftware/nceplibs
 
 RUN mkdir -p $NCEPLIBS_DIR/src && cd $NCEPLIBS_DIR/src \
-  && git clone -b v2.4.1 --recursive https://github.com/NOAA-EMC/NCEPLIBS-bacio \
-  && mkdir NCEPLIBS-bacio/build && cd NCEPLIBS-bacio/build \
-  && cmake -DCMAKE_INSTALL_PREFIX=$NCEPLIBS_DIR .. \
-  && make VERBOSE=1 -j \
-  && make install
+   && git clone -b v2.4.1 --depth 1 --recursive https://github.com/NOAA-EMC/NCEPLIBS-bacio \
+   && mkdir NCEPLIBS-bacio/build && cd NCEPLIBS-bacio/build \
+   && cmake -DCMAKE_INSTALL_PREFIX=$NCEPLIBS_DIR .. \
+   && make VERBOSE=$VERBOSE -j \
+   && make install
 
 RUN cd $NCEPLIBS_DIR/src \
-  && git clone -b v2.3.3 --recursive https://github.com/NOAA-EMC/NCEPLIBS-sp \
+  && git clone -b v2.3.3 --depth 1 --recursive https://github.com/NOAA-EMC/NCEPLIBS-sp \
   && mkdir NCEPLIBS-sp/build && cd NCEPLIBS-sp/build \
   && cmake -DCMAKE_INSTALL_PREFIX=$NCEPLIBS_DIR .. \
-  && make VERBOSE=1 -j \
+  && make VERBOSE=$VERBOSE -j \
   && make install
 
 RUN cd $NCEPLIBS_DIR/src \
-  && git clone -b v2.11.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-w3emc \
+  && git clone -b v2.11.0 --depth 1 --recursive https://github.com/NOAA-EMC/NCEPLIBS-w3emc \
   && mkdir NCEPLIBS-w3emc/build && cd NCEPLIBS-w3emc/build \
   && cmake -DCMAKE_INSTALL_PREFIX=$NCEPLIBS_DIR .. \
-  && make VERBOSE=1 -j \
+  && make VERBOSE=$VERBOSE -j \
   && make install
 
 ENV bacio_ROOT=/comsoftware/nceplibs
@@ -81,7 +110,7 @@ RUN if [ -z "$PR_NUMBER" ]; then \
         && cd ccpp-scm \
         && git fetch origin pull/${PR_NUMBER}/head:test_pr \
         && git checkout test_pr \
-        && git submodule update --init --recursive; \
+        && git submodule update --init --recursive --depth 1; \
     fi
 
 RUN mkdir /comsoftware/ccpp-scm/scm/bin \
@@ -89,9 +118,6 @@ RUN mkdir /comsoftware/ccpp-scm/scm/bin \
   && cmake ../src \
   && make -j
 
-RUN cd /comsoftware/ccpp-scm/ \
-  && ./contrib/get_all_static_data.sh \
-  && ./contrib/get_thompson_tables.sh
 
 # The analysis scripts have options for using LaTeX when making figure labels.
 # If you would like to install LaTeK, uncomment the section below.
@@ -109,4 +135,11 @@ ENV SCM_ROOT=/comsoftware/ccpp-scm/
 # For interactive use, vim mouse settings are infuriating
 RUN echo "set mouse=" > ~/.vimrc
 
-ENTRYPOINT ["sh", "-c", "./contrib/get_aerosol_climo.sh && cd /comsoftware/ccpp-scm/scm/bin"]
+# only download test data when PR is being tested
+ENTRYPOINT ["sh", "-c", "\
+if [ -n \"$PR_NUMBER\" ]; then \
+  ./contrib/get_aerosol_climo.sh && \
+  ./contrib/get_all_static_data.sh && \
+  ./contrib/get_thompson_tables.sh; \
+fi && \
+cd /comsoftware/ccpp-scm/scm/bin"]


### PR DESCRIPTION
SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES: The `build_test_and_push_docker` Github CI always fails for an unknown reason on the `main` branch, turning this check off. The other changes are attempt to reduce the amount of time spent during the Docker image build and reduce the information produced.  Changes are:
- Turn off `build_test_and_push_docker` Github CI for merge of PR into `main` branch
- Unifying apt-get install into one command (modern coding practice)
- using slim debian docker image
- git clones of depth=1 so less data is downloaded
- download test datasets only if running in the PR CI
- `build_test_and_push_docker` Github CI runs 3 minutes faster

TESTS CONDUCTED: Built docker image locally