### PR TITLE
enhancement: turn on all single precision RTs

### DIFF
--- a/test/rt_test_cases_sp.py
+++ b/test/rt_test_cases_sp.py
@@ -2,7 +2,7 @@ run_list = [\
             #----------------------------------------------------------------------------------------------------------------------------------------------
             # CCPP-SCM single precision supported suites
             #----------------------------------------------------------------------------------------------------------------------------------------------
-#            {"case": "arm_sgp_summer_1997_A", "suite": "SCM_HRRR_gf"},                                                                                    \
+            {"case": "arm_sgp_summer_1997_A", "suite": "SCM_HRRR_gf"},                                                                                    \
             {"case": "twpice",                "suite": "SCM_HRRR_gf"},                                                                                    \
             {"case": "bomex",                 "suite": "SCM_HRRR_gf"},                                                                                    \
             {"case": "astex",                 "suite": "SCM_HRRR_gf"},                                                                                    \


### PR DESCRIPTION
SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES: Turn on `arm_sgp_summer_1997_A` single precision case to make sure all single precision RTs are passing.