### PR TITLE
fix: write to standard io error unit

### DIFF
--- a/scm/src/CCPP_typedefs.F90
+++ b/scm/src/CCPP_typedefs.F90
@@ -850,7 +850,7 @@ contains
       endif
       if (Model%satmedmf) Interstitial%nvdiff = Interstitial%nvdiff + 1
     elseif ( Model%imp_physics == Model%imp_physics_nssl ) then
-      if (Model%me == Model%master)  write(0,*) 'nssl_settings1: nvdiff,ntrac = ', Interstitial%nvdiff, Model%ntrac
+      if (Model%me == Model%master)  write(*,*) 'nssl_settings1: nvdiff,ntrac = ', Interstitial%nvdiff, Model%ntrac
 
       IF ( Model%nssl_hail_on ) THEN
         Interstitial%nvdiff = 16 !  Model%ntrac ! 17
@@ -862,7 +862,7 @@ contains
       IF ( Model%nssl_ccn_on ) THEN
         Interstitial%nvdiff = Interstitial%nvdiff + 1
       ENDIF
-      if (Model%me == Model%master)  write(0,*) 'nssl_settings2: nvdiff,ntrac = ', Interstitial%nvdiff, Model%ntrac
+      if (Model%me == Model%master)  write(*,*) 'nssl_settings2: nvdiff,ntrac = ', Interstitial%nvdiff, Model%ntrac
 
     elseif (Model%imp_physics == Model%imp_physics_wsm6) then
       Interstitial%nvdiff = Model%ntrac -3

--- a/scm/src/scm.F90
+++ b/scm/src/scm.F90
@@ -6,6 +6,7 @@ contains
 
 subroutine scm_main_sub()
 
+  use iso_fortran_env, only: error_unit
   use scm_kinds, only: sp, dp, qp
   use scm_input
   use scm_utils
@@ -44,7 +45,7 @@ subroutine scm_main_sub()
 
   call MPI_INIT(ierr)
   if (ierr/=0) then
-      write(*,*) 'An error occurred in MPI_INIT: ', ierr
+      write(error_unit,*) 'An error occurred in MPI_INIT: ', ierr
       error stop
   end if
   fcst_mpi_comm = MPI_COMM_WORLD
@@ -59,7 +60,7 @@ subroutine scm_main_sub()
     case(1)
       call get_case_init_DEPHY(scm_state, scm_input_instance)
     case default
-      write(*,*) 'An unrecognized specification of the input_type namelist variable is being used. Exiting...'
+      write(error_unit,*) 'An unrecognized specification of the input_type namelist variable is being used. Exiting...'
       error stop
   end select
 
@@ -153,10 +154,10 @@ subroutine scm_main_sub()
 
   !check for problematic diagnostic and radiation periods
   if (mod(physics%Model%nszero,scm_state%n_itt_out) /= 0) then
-    write(*,*) "***ERROR***: The diagnostic output period must be a multiple of the output period."
-    write(*,*) "From ", adjustl(trim(scm_state%physics_nml)), ", fhzero = ",physics%Model%fhzero
-    write(*,*) "implying a diagnostic output period of ", physics%Model%nszero*scm_state%dt, "seconds."
-    write(*,*) "The given output period in the case configuration namelist is ", scm_state%output_period,"seconds."
+    write(error_unit,*) "***ERROR***: The diagnostic output period must be a multiple of the output period."
+    write(error_unit,*) "From ", adjustl(trim(scm_state%physics_nml)), ", fhzero = ",physics%Model%fhzero
+    write(error_unit,*) "implying a diagnostic output period of ", physics%Model%nszero*scm_state%dt, "seconds."
+    write(error_unit,*) "The given output period in the case configuration namelist is ", scm_state%output_period,"seconds."
     error stop
   end if
 
@@ -195,11 +196,11 @@ subroutine scm_main_sub()
 
   !initialize the column's physics
 
-  write(0,'(a,i0,a)') "Calling ccpp_physics_init with suite '" // trim(trim(adjustl(scm_state%physics_suite_name))) // "'"
+  write(*,'(a,i0,a)') "Calling ccpp_physics_init with suite '" // trim(trim(adjustl(scm_state%physics_suite_name))) // "'"
   call ccpp_physics_init(cdata, suite_name=trim(trim(adjustl(scm_state%physics_suite_name))), ierr=ierr)
-  write(0,'(a,i0,a,i0)') "Called ccpp_physics_init with suite '" // trim(trim(adjustl(scm_state%physics_suite_name))) // "', ierr=", ierr
+  write(*,'(a,i0,a,i0)') "Called ccpp_physics_init with suite '" // trim(trim(adjustl(scm_state%physics_suite_name))) // "', ierr=", ierr
   if (ierr/=0) then
-      write(*,'(a,i0,a)') 'An error occurred in ccpp_physics_init: ' // trim(cdata%errmsg) // '. Exiting...'
+      write(error_unit,'(a,i0,a)') 'An error occurred in ccpp_physics_init: ' // trim(cdata%errmsg) // '. Exiting...'
       error stop
   end if
 
@@ -289,7 +290,7 @@ subroutine scm_main_sub()
 
     call ccpp_physics_timestep_init(cdata, suite_name=trim(adjustl(scm_state%physics_suite_name)), ierr=ierr)
     if (ierr/=0) then
-        write(*,'(a,i0,a)') 'An error occurred in ccpp_physics_timestep_init: ' // trim(cdata%errmsg) // '. Exiting...'
+        write(error_unit,'(a,i0,a)') 'An error occurred in ccpp_physics_timestep_init: ' // trim(cdata%errmsg) // '. Exiting...'
         error stop
     end if
 
@@ -312,13 +313,13 @@ subroutine scm_main_sub()
 
     call ccpp_physics_run(cdata, suite_name=trim(adjustl(scm_state%physics_suite_name)), ierr=ierr)
     if (ierr/=0) then
-        write(*,'(a,i0,a)') 'An error occurred in ccpp_physics_run: ' // trim(cdata%errmsg) // '. Exiting...'
+        write(error_unit,'(a,i0,a)') 'An error occurred in ccpp_physics_run: ' // trim(cdata%errmsg) // '. Exiting...'
         error stop
     end if
 
     call ccpp_physics_timestep_finalize(cdata, suite_name=trim(adjustl(scm_state%physics_suite_name)), ierr=ierr)
     if (ierr/=0) then
-        write(*,'(a,i0,a)') 'An error occurred in ccpp_physics_timestep_finalize: ' // trim(cdata%errmsg) // '. Exiting...'
+        write(error_unit,'(a,i0,a)') 'An error occurred in ccpp_physics_timestep_finalize: ' // trim(cdata%errmsg) // '. Exiting...'
         error stop
     end if
 
@@ -430,13 +431,13 @@ subroutine scm_main_sub()
   call ccpp_physics_finalize(cdata, suite_name=trim(trim(adjustl(scm_state%physics_suite_name))), ierr=ierr)
 
   if (ierr/=0) then
-      write(*,'(a,i0,a)') 'An error occurred in ccpp_physics_finalize: ' // trim(cdata%errmsg) // '. Exiting...'
+      write(error_unit,'(a,i0,a)') 'An error occurred in ccpp_physics_finalize: ' // trim(cdata%errmsg) // '. Exiting...'
       error stop
   end if
 
   call MPI_FINALIZE(ierr)
   if (ierr/=0) then
-      write(*,*) 'An error occurred in MPI_FINALIZE: ', ierr
+      write(error_unit,*) 'An error occurred in MPI_FINALIZE: ', ierr
       error stop
   end if
 

--- a/scm/src/scm_forcing.F90
+++ b/scm/src/scm_forcing.F90
@@ -3,6 +3,7 @@
 
 module scm_forcing
 
+use iso_fortran_env, only: error_unit
 use scm_kinds, only: sp, dp, qp
 use scm_utils, only: interpolate_to_grid_centers, find_vertical_index_pressure
 
@@ -791,7 +792,7 @@ subroutine apply_forcing_leapfrog(scm_state)
 
   select case(scm_state%mom_forcing_type)
     case (1)
-      write(*,*) 'momentum forcing type = 1 is not implemented. Pick 2 or 3. Stopping...'
+      write(error_unit,*) 'momentum forcing type = 1 is not implemented. Pick 2 or 3. Stopping...'
       error stop
     case (2)
       !> - Calculate change in state momentum variables due to vertical advection (subsidence).
@@ -990,7 +991,7 @@ subroutine apply_forcing_forward_Euler(scm_state, in_spinup)
   else
     select case(scm_state%mom_forcing_type)
       case (1)
-        write(*,*) 'momentum forcing type = 1 is not implemented. Pick 2 or 3. Stopping...'
+        write(error_unit,*) 'momentum forcing type = 1 is not implemented. Pick 2 or 3. Stopping...'
         error stop
       case (2)
         !> - Calculate change in state momentum variables due to vertical advection (subsidence).

--- a/scm/src/scm_input.F90
+++ b/scm/src/scm_input.F90
@@ -4,6 +4,7 @@
 
 module scm_input
 
+use iso_fortran_env, only: error_unit
 use scm_kinds, only : sp, dp, qp
 use netcdf
 use scm_type_defs, only: character_length
@@ -126,7 +127,7 @@ subroutine get_config_nml(scm_state)
 
   open(unit=10, file=experiment_namelist, status='old', action='read', iostat=ioerror)
   if(ioerror /= 0) then
-    write(*,'(a,i0)') 'There was an error opening the file ' // experiment_namelist // &
+    write(error_unit,'(a,i0)') 'There was an error opening the file ' // experiment_namelist // &
                       '; error code = ', ioerror
     error stop "error opening namelist"
   else
@@ -134,7 +135,7 @@ subroutine get_config_nml(scm_state)
   end if
 
   if(ioerror /= 0) then
-    write(*,'(a,i0)') 'There was an error reading the namelist case_config in the file '&
+    write(error_unit,'(a,i0)') 'There was an error reading the namelist case_config in the file '&
                       // experiment_namelist // '; error code = ',ioerror
     error stop "error opening namelist"
   end if
@@ -499,7 +500,7 @@ subroutine get_case_init(scm_state, scm_input)
   call NetCDF_read_var(grp_ncid, "thetail", .False., input_thetail)
   call NetCDF_read_var(grp_ncid, "temp", .False., input_temp)
   if (maxval(input_thetail) < 0 .and. maxval(input_temp) < 0) then
-    write(*,*) "One of thetail or temp variables must be present in ",trim(adjustl(scm_state%case_name))//'.nc',". Stopping..."
+    write(error_unit,*) "One of thetail or temp variables must be present in ",trim(adjustl(scm_state%case_name))//'.nc',". Stopping..."
     error stop "One of thetail or temp variables"
   end if
   call NetCDF_read_var(grp_ncid, "qt",    .True., input_qt   )
@@ -1212,8 +1213,8 @@ subroutine get_case_init_DEPHY(scm_state, scm_input)
   else if (adjustl(trim(tmpUnits)) == 'm') then
     lev_in_altitude = .true.
   else
-    write(0,'(a,i0,a)') "The variable 'lev' in the case data file had units different than 'm', 'pa', or 'Pa', but it is expected to be altitude in m or pressure in Pa. Stopping..."
-    STOP
+    write(error_unit,'(a,i0,a)') "The variable 'lev' in the case data file had units different than 'm', 'pa', or 'Pa', but it is expected to be altitude in m or pressure in Pa. Stopping..."
+    error stop
   end if
 
   !### TO BE USED IF DEPHY-SCM can be extended to include model ICs ###
@@ -2032,7 +2033,7 @@ subroutine get_case_init_DEPHY(scm_state, scm_input)
     end if !ql test
   else
     !no qv or qt
-    write(*,*) 'When reading '//trim(adjustl(scm_state%case_name))//'.nc, all of the supported moisture variables (qv, qt, rv, rt) were missing. Stopping...'
+    write(error_unit,*) 'When reading '//trim(adjustl(scm_state%case_name))//'.nc, all of the supported moisture variables (qv, qt, rv, rt) were missing. Stopping...'
     error stop "Aall of the supported moisture variables (qv, qt, rv, rt) were missing"
   end if
 
@@ -2062,7 +2063,7 @@ subroutine get_case_init_DEPHY(scm_state, scm_input)
     !since thetail is present, choose to use it, and set the alternative temperature to missing, even if it is also present in the file
     scm_input%input_temp = missing_value
   else
-    write(*,*) 'When reading '//trim(adjustl(scm_state%case_name))//'.nc, all of the supported temperature variables (temp, theta, thetal) were missing. Stopping...'
+    write(error_unit,*) 'When reading '//trim(adjustl(scm_state%case_name))//'.nc, all of the supported temperature variables (temp, theta, thetal) were missing. Stopping...'
     error stop "All of the supported temperature variables (temp, theta, thetal) were missing"
   end if
 
@@ -2131,7 +2132,7 @@ subroutine get_case_init_DEPHY(scm_state, scm_input)
 
   if (input_surfaceForcingTemp == 'ts') then
     if (maxval(input_force_ts) < 0) then
-      write(*,*) 'The global attribute surfaceForcing in '//trim(adjustl(scm_state%case_name))//'.nc indicates that the variable ts should be present, but it is missing. Stopping ...'
+      write(error_unit,*) 'The global attribute surfaceForcing in '//trim(adjustl(scm_state%case_name))//'.nc indicates that the variable ts should be present, but it is missing. Stopping ...'
       error stop "The global attribute surfaceForcing indicates that the variable ts should be present, but it is missing"
     else
       !overwrite sfc_flux_spec
@@ -2163,7 +2164,7 @@ subroutine get_case_init_DEPHY(scm_state, scm_input)
 
     !kinematic surface fluxes are specified (but may need to be converted)
     if (maxval(input_force_wpthetap(:)) < missing_value_eps) then
-      write(*,*) 'The global attribute surfaceForcing in '//trim(adjustl(scm_state%case_name))//'.nc indicates that the variable wpthetap should be present, but it is missing. Stopping ...'
+      write(error_unit,*) 'The global attribute surfaceForcing in '//trim(adjustl(scm_state%case_name))//'.nc indicates that the variable wpthetap should be present, but it is missing. Stopping ...'
       error stop "The global attribute surfaceForcing indicates that the variable wpthetap should be present, but it is missing."
     else
       !convert from theta to T
@@ -2193,7 +2194,7 @@ subroutine get_case_init_DEPHY(scm_state, scm_input)
     end if
 
     if (maxval(input_force_wpqvp(:)) < missing_value_eps .and. maxval(input_force_wpqtp(:)) < missing_value_eps) then
-      write(*,*) 'The global attribute surfaceForcing in '//trim(adjustl(scm_state%case_name))//'.nc indicates that the variable wpqvp, wpqtp, wprvp, or wprtp should be present, but all are missing. Stopping ...'
+      write(error_unit,*) 'The global attribute surfaceForcing in '//trim(adjustl(scm_state%case_name))//'.nc indicates that the variable wpqvp, wpqtp, wprvp, or wprtp should be present, but all are missing. Stopping ...'
       error stop "The global attribute surfaceForcing indicates that the variable wpqvp, wpqtp, wprvp, or wprtp should be present, but all are missing."
     else
       if (maxval(input_force_wpqvp(:)) > missing_value_eps) then !use wpqvp if available
@@ -2227,14 +2228,14 @@ subroutine get_case_init_DEPHY(scm_state, scm_input)
 
 
     if (maxval(input_force_sfc_sens_flx(:)) < missing_value_eps) then
-      write(*,*) 'The global attribute surfaceForcing in '//trim(adjustl(scm_state%case_name))//'.nc indicates that the variable sfc_sens_flx should be present, but it is missing. Stopping ...'
+      write(error_unit,*) 'The global attribute surfaceForcing in '//trim(adjustl(scm_state%case_name))//'.nc indicates that the variable sfc_sens_flx should be present, but it is missing. Stopping ...'
       error stop "The global attribute surfaceForcing in indicates that the variable sfc_sens_flx should be present, but it is missing."
     else
       scm_input%input_sh_flux_sfc = input_force_sfc_sens_flx(:)
     end if
 
     if (maxval(input_force_sfc_lat_flx(:)) < missing_value_eps) then
-      write(*,*) 'The global attribute surfaceForcing in '//trim(adjustl(scm_state%case_name))//'.nc indicates that the variable sfc_lat_flx should be present, but it is missing. Stopping ...'
+      write(error_unit,*) 'The global attribute surfaceForcing in '//trim(adjustl(scm_state%case_name))//'.nc indicates that the variable sfc_lat_flx should be present, but it is missing. Stopping ...'
       error stop "The global attribute surfaceForcing indicates that the variable sfc_lat_flx should be present, but it is missing."
     else
       scm_input%input_lh_flux_sfc = input_force_sfc_lat_flx(:)
@@ -2349,7 +2350,7 @@ subroutine get_case_init_DEPHY(scm_state, scm_input)
   else if (input_surfaceForcingWind == 'ustar') then
     !not supported
     scm_state%surface_momentum_control = 1
-    write(*,*) 'The global attribute surfaceForcingWind in '//trim(adjustl(scm_state%case_name))//'.nc indicates that surface wind is controlled by a specified time-series of ustar. This is currently not supported. Stopping ...'
+    write(error_unit,*) 'The global attribute surfaceForcingWind in '//trim(adjustl(scm_state%case_name))//'.nc indicates that surface wind is controlled by a specified time-series of ustar. This is currently not supported. Stopping ...'
     error stop "The global attribute surfaceForcingWind indicates that surface wind is controlled by a specified time-series of ustar. This is currently not supported."
   end if
 
@@ -2451,7 +2452,7 @@ subroutine get_case_init_DEPHY(scm_state, scm_input)
   if (char_rad_temp == 'adv' .or. char_rad_theta == 'adv' .or. char_rad_thetal == 'adv') then
     scm_state%force_rad_T = 4
     if (scm_state%force_adv_T == 0) then
-      write(*,*) 'The global attribute rad_temp, rad_theta, or rad_thetal in '//trim(adjustl(scm_state%case_name))//'.nc indicates that radiative forcing is included in the advection term, but there is no advection term. Stopping ...'
+      write(error_unit,*) 'The global attribute rad_temp, rad_theta, or rad_thetal in '//trim(adjustl(scm_state%case_name))//'.nc indicates that radiative forcing is included in the advection term, but there is no advection term. Stopping ...'
       error stop "The global attribute rad_temp, rad_theta, or rad_thetal indicates that radiative forcing is included in the advection term, but there is no advection term."
     end if
   else if (rad_temp > 0) then
@@ -2747,7 +2748,7 @@ subroutine get_reference_profile(scm_state, scm_reference)
     case (1)
       open(unit=1, file='McCProfiles.dat', status='old', action='read', iostat=ioerror)
       if(ioerror /= 0) then
-        write(*,*) 'There was an error opening the file McCprofiles.dat in the processed_case_input directory. &
+        write(error_unit,*) 'There was an error opening the file McCprofiles.dat in the processed_case_input directory. &
           &Error code = ',ioerror
         error stop "There was an error opening the file McCprofiles.dat in the processed_case_input directory."
       endif
@@ -2857,7 +2858,7 @@ subroutine get_tracers(tracer_names, tracer_types)
             tracer_types(i) = 0 ! temporary until SCM is configured to work with GOCART
         end do
     else
-        write(*,'(a,i0)') 'There was an error opening the file ' // FILE_NAME // &
+        write(error_unit,'(a,i0)') 'There was an error opening the file ' // FILE_NAME // &
                           '; error code = ', rc
         error stop "Error opening tracers file"
     end if

--- a/scm/src/scm_setup.F90
+++ b/scm/src/scm_setup.F90
@@ -4,6 +4,7 @@
 
 module scm_setup
 
+use iso_fortran_env, only: error_unit
 use scm_kinds, only: sp, dp, qp
 use scm_physical_constants, only: con_hvap, con_hfus, con_cp, con_rocp, con_pi
 use scm_utils, only: interpolate_to_grid_centers
@@ -354,7 +355,7 @@ subroutine GFS_suite_setup (Model, Statein, Stateout, Sfcprop,                  
     if (nthreads == 1) then
       call Interstitial(1)%create(n_cols, Model)
     else
-      print *,' CCPP SCM is only set up to use one thread - shutting down'
+      write(error_unit,*) ' CCPP SCM is only set up to use one thread - shutting down'
       error stop
     end if
 
@@ -384,15 +385,15 @@ subroutine GFS_suite_setup (Model, Statein, Stateout, Sfcprop,                  
 
   !--- lsidea initialization
   if (Model%lsidea) then
-    print *,' LSIDEA is active but needs to be reworked for FV3 - shutting down'
+    write(error_unit,*) ' LSIDEA is active but needs to be reworked for FV3 - shutting down'
     error stop
     !--- NEED TO get the logic from the old phys/gloopb.f initialization area
   endif
 
   if(Model%do_ca)then
-    print *,'Cellular automata cannot be used when CCPP is turned on until'
-    print *,'the stochastic physics pattern generation code has been pulled'
-    print *,'out of the FV3 repository and updated with the CCPP version.'
+    write(error_unit,*) 'Cellular automata cannot be used when CCPP is turned on until'
+    write(error_unit,*) 'the stochastic physics pattern generation code has been pulled'
+    write(error_unit,*) 'out of the FV3 repository and updated with the CCPP version.'
     error stop
   endif
 

--- a/scm/src/scm_time_integration.F90
+++ b/scm/src/scm_time_integration.F90
@@ -3,6 +3,7 @@
 
 module scm_time_integration
 
+use iso_fortran_env, only: error_unit
 use scm_kinds, only: sp, dp, qp
 use scm_forcing
 
@@ -134,7 +135,7 @@ subroutine do_time_step(scm_state, physics, cdata, in_spinup)
 
   call ccpp_physics_timestep_init(cdata, suite_name=trim(adjustl(scm_state%physics_suite_name)), ierr=ierr)
   if (ierr/=0) then
-      write(*,'(a,i0,a)') 'An error occurred in ccpp_physics_timestep_init: ' // trim(cdata%errmsg) // '. Exiting...'
+      write(error_unit,'(a,i0,a)') 'An error occurred in ccpp_physics_timestep_init: ' // trim(cdata%errmsg) // '. Exiting...'
       error stop trim(cdata%errmsg)
   end if
 
@@ -157,13 +158,13 @@ subroutine do_time_step(scm_state, physics, cdata, in_spinup)
 
   call ccpp_physics_run(cdata, suite_name=trim(adjustl(scm_state%physics_suite_name)), ierr=ierr)
   if (ierr/=0) then
-      write(*,'(a,i0,a)') 'An error occurred in ccpp_physics_run: ' // trim(cdata%errmsg) // '. Exiting...'
+      write(error_unit,'(a,i0,a)') 'An error occurred in ccpp_physics_run: ' // trim(cdata%errmsg) // '. Exiting...'
       error stop trim(cdata%errmsg)
   end if
 
   call ccpp_physics_timestep_finalize(cdata, suite_name=trim(adjustl(scm_state%physics_suite_name)), ierr=ierr)
   if (ierr/=0) then
-      write(*,'(a,i0,a)') 'An error occurred in ccpp_physics_timestep_finalize: ' // trim(cdata%errmsg) // '. Exiting...'
+      write(error_unit,'(a,i0,a)') 'An error occurred in ccpp_physics_timestep_finalize: ' // trim(cdata%errmsg) // '. Exiting...'
       error stop trim(cdata%errmsg)
   end if
 

--- a/scm/src/scm_type_defs.F90
+++ b/scm/src/scm_type_defs.F90
@@ -7,6 +7,7 @@ module scm_type_defs
 !! \htmlinclude scm_type_defs.html
 !!
 
+  use iso_fortran_env, only: error_unit
   use scm_kinds, only: sp, dp, qp
   use GFS_typedefs,   only: GFS_control_type,      &
                             GFS_statein_type,      &
@@ -1080,7 +1081,7 @@ module scm_type_defs
       ! Orographical data (2D)
       !
       if (scm_state%model_ics) then
-        write(0,'(a)') "Setting internal physics variables from the orographic section of the case input file (scalars)..."
+        write(*,'(a)') "Setting internal physics variables from the orographic section of the case input file (scalars)..."
         call conditionally_set_var(scm_input%input_stddev,    physics%Sfcprop%hprime(i,1),  "stddev",    .true., missing_var(1))
         call conditionally_set_var(scm_input%input_convexity, physics%Sfcprop%hprime(i,2),  "convexity", .true., missing_var(2))
         call conditionally_set_var(scm_input%input_oa1,       physics%Sfcprop%hprime(i,3),  "oa1",       .true., missing_var(3))
@@ -1105,10 +1106,10 @@ module scm_type_defs
         
         n = 21
         if ( i==1 .and. ANY( missing_var(1:n) ) ) then
-          write(0,'(a)') "INPUT CHECK: Some missing input data was found related to (potentially non-required) orography and gravity wave drag parameters. This may lead to crashes or other strange behavior."
-          write(0,'(a)') "Check scm_type_defs.F90/physics_set to see the names of variables that are missing, corresponding to the following indices:"
+          write(error_unit,'(a)') "INPUT CHECK: Some missing input data was found related to (potentially non-required) orography and gravity wave drag parameters. This may lead to crashes or other strange behavior."
+          write(error_unit,'(a)') "Check scm_type_defs.F90/physics_set to see the names of variables that are missing, corresponding to the following indices:"
           do j=1, n
-            if (missing_var(j)) write(0,'(a,i0)') "variable index ",j
+            if (missing_var(j)) write(error_unit,'(a,i0)') "variable index ",j
           end do
         end if
         missing_var = .false.
@@ -1118,7 +1119,7 @@ module scm_type_defs
       ! Surface data (2D)
       !
       if (scm_state%model_ics .or. scm_state%lsm_ics) then
-        write(0,'(a)') "Setting internal physics variables from the surface section of the case input file (scalars)..."
+        write(*,'(a)') "Setting internal physics variables from the surface section of the case input file (scalars)..."
         call conditionally_set_var(scm_input%input_slmsk,     physics%Sfcprop%slmsk(i),  "slmsk",    (.not. physics%Model%frac_grid), missing_var(1))
         call conditionally_set_var(scm_input%input_tsfco,     physics%Sfcprop%tsfco(i),  "tsfco",    .true.,  missing_var(2))
         call conditionally_set_var(scm_input%input_weasd,     physics%Sfcprop%weasd(i),  "weasd",    .true.,  missing_var(3))
@@ -1196,10 +1197,10 @@ module scm_type_defs
         !write out warning if missing data for non-required variables
         n = 50
         if ( i==1 .and. ANY( missing_var(1:n) ) ) then
-          write(0,'(a)') "INPUT CHECK: Some missing input data was found related to (potentially non-required) surface variables. This may lead to crashes or other strange behavior."
-          write(0,'(a)') "Check scm_type_defs.F90/physics_set to see the names of variables that are missing, corresponding to the following indices:"
+          write(error_unit,'(a)') "INPUT CHECK: Some missing input data was found related to (potentially non-required) surface variables. This may lead to crashes or other strange behavior."
+          write(error_unit,'(a)') "Check scm_type_defs.F90/physics_set to see the names of variables that are missing, corresponding to the following indices:"
           do j=1, n
-            if (missing_var(j)) write(0,'(a,i0)') "variable index ",j
+            if (missing_var(j)) write(error_unit,'(a,i0)') "variable index ",j
           end do
         end if
         missing_var = .false.
@@ -1342,7 +1343,7 @@ module scm_type_defs
           physics%Sfcprop%dt_cool(i) = real_zero
           physics%Sfcprop%qrain(i)   = real_zero
         elseif (physics%Model%nstf_name(2) == 0) then         ! nsst restart
-          write(0,'(a)') "Setting internal physics variables from the NSST section of the case input file (scalars)..."
+          write(*,'(a)') "Setting internal physics variables from the NSST section of the case input file (scalars)..."
           call conditionally_set_var(scm_input%input_tref,    physics%Sfcprop%tref(i),    "tref",    .true., missing_var(1))
           call conditionally_set_var(scm_input%input_z_c,     physics%Sfcprop%z_c(i),     "z_c",     .true., missing_var(2))
           call conditionally_set_var(scm_input%input_c_0,     physics%Sfcprop%c_0(i),     "c_0",     .true., missing_var(3))
@@ -1376,10 +1377,10 @@ module scm_type_defs
 
         n = 3
         if ( i==1 .and. ANY( missing_var(1:n) ) ) then 
-           write(0,'(a)') "INPUT CHECK: Some missing input data was found related to surface variables needed by the LSM. Due to this, a cold-start algorithm to initialize variables will be used."
-           write(0,'(a)') "Check scm_type_defs.F90/physics_set to see the names of variables that are missing, corresponding to the following indices:"
+           write(error_unit,'(a)') "INPUT CHECK: Some missing input data was found related to surface variables needed by the LSM. Due to this, a cold-start algorithm to initialize variables will be used."
+           write(error_unit,'(a)') "Check scm_type_defs.F90/physics_set to see the names of variables that are missing, corresponding to the following indices:"
            do j=1, n
-              if (missing_var(j)) write(0,'(a,i0)') "variable index ",j
+              if (missing_var(j)) write(error_unit,'(a,i0)') "variable index ",j
            end do
         end if
      end if

--- a/scm/src/scm_utils.F90
+++ b/scm/src/scm_utils.F90
@@ -3,6 +3,7 @@
 
 module scm_utils
 
+use iso_fortran_env, only: error_unit
 use scm_kinds, only: sp, dp, qp, kind_scm_dp
 use scm_physical_constants, only: con_rd, con_g
 
@@ -172,6 +173,7 @@ end function gcd
 end module scm_utils
 
 module NetCDF_read
+  use iso_fortran_env, only: error_unit
   use scm_kinds, only : sp, dp, qp, kind_scm_dp
   use netcdf
 
@@ -559,7 +561,7 @@ module NetCDF_read
     if (req) then
       ierr = NF90_INQUIRE_ATTRIBUTE(ncid, var_id, att_name)
       if (ierr /= NF90_NOERR) then
-        write(*,*) 'There was an error reading the required '//adjustl(trim(att_name))//' attribute. Stopping...'
+        write(error_unit,*) 'There was an error reading the required '//adjustl(trim(att_name))//' attribute. Stopping...'
         error stop "There was an error reading the required attribute"
       else
         call check(NF90_GET_ATT(ncid, var_id, att_name, att_data),att_name)
@@ -587,7 +589,7 @@ module NetCDF_read
     if (req) then
       ierr = NF90_INQUIRE_ATTRIBUTE(ncid, var_id, att_name)
       if (ierr /= NF90_NOERR) then
-        write(*,*) 'There was an error reading the required '//adjustl(trim(att_name))//' attribute. Stopping...'
+        write(error_unit,*) 'There was an error reading the required '//adjustl(trim(att_name))//' attribute. Stopping...'
         error stop "There was an error reading the required attribute"
       else
         call check(NF90_GET_ATT(ncid, var_id, att_name, att_data),att_name)
@@ -615,7 +617,7 @@ module NetCDF_read
     if (req) then
       ierr = NF90_INQUIRE_ATTRIBUTE(ncid, var_id, att_name)
       if (ierr /= NF90_NOERR) then
-        write(*,*) 'There was an error reading the required '//adjustl(trim(att_name))//' attribute. Stopping...'
+        write(error_unit,*) 'There was an error reading the required '//adjustl(trim(att_name))//' attribute. Stopping...'
         error stop "There was an error reading the required attribute"
       else
         call check(NF90_GET_ATT(ncid, var_id, att_name, att_data),att_name)
@@ -644,7 +646,7 @@ module NetCDF_read
     if (req) then
       ierr = NF90_INQUIRE_ATTRIBUTE(ncid, var_id, att_name, xtype = type)
       if (ierr /= NF90_NOERR) then
-        write(*,*) 'There was an error reading the required '//adjustl(trim(att_name))//' attribute. Stopping...'
+        write(error_unit,*) 'There was an error reading the required '//adjustl(trim(att_name))//' attribute. Stopping...'
         error stop "There was an error reading the required attribute"
       else
         if (type == NF90_CHAR) then
@@ -690,7 +692,7 @@ module NetCDF_read
     if (var_ctl > 0) then
       call NetCDF_read_var(ncid, var_name, .False., var_data)
       if (maxval(var_data) < missing_value_eps) then
-        write(*,*) 'The global attribute '//var_att//' in '//filename//' indicates that the variable '//var_name//' should be present, but it is missing. Stopping ...'
+        write(error_unit,*) 'The global attribute '//var_att//' in '//filename//' indicates that the variable '//var_name//' should be present, but it is missing. Stopping ...'
         error stop "Missing variable"
       end if
     else
@@ -709,7 +711,7 @@ module NetCDF_read
     if (var_ctl > 0) then
       call NetCDF_read_var(ncid, var_name, .False., var_data)
       if (maxval(var_data) < missing_value_eps) then
-        write(*,*) 'The global attribute '//var_att//' in '//filename//' indicates that the variable '//var_name//' should be present, but it is missing. Stopping ...'
+        write(error_unit,*) 'The global attribute '//var_att//' in '//filename//' indicates that the variable '//var_name//' should be present, but it is missing. Stopping ...'
         error stop "Missing variable"
       end if
     else
@@ -728,7 +730,7 @@ module NetCDF_read
     if (var_ctl > 0) then
       call NetCDF_read_var(ncid, var_name, .False., var_data)
       if (maxval(var_data) < missing_value_eps) then
-        write(*,*) 'The global attribute '//var_att//' in '//filename//' indicates that the variable '//var_name//' should be present, but it is missing. Stopping ...'
+        write(error_unit,*) 'The global attribute '//var_att//' in '//filename//' indicates that the variable '//var_name//' should be present, but it is missing. Stopping ...'
         error stop "Missing variable"
       end if
     else
@@ -747,7 +749,7 @@ module NetCDF_read
     if (var_ctl > 0) then
       call NetCDF_read_var(ncid, var_name, .False., var_data)
       if (maxval(var_data) < missing_value_eps) then
-        write(*,*) 'The global attribute '//var_att//' in '//filename//' indicates that the variable '//var_name//' should be present, but it is missing. Stopping ...'
+        write(error_unit,*) 'The global attribute '//var_att//' in '//filename//' indicates that the variable '//var_name//' should be present, but it is missing. Stopping ...'
         error stop "Missing variable"
       end if
     else
@@ -758,6 +760,7 @@ module NetCDF_read
 end module NetCDF_read
 
 module NetCDF_def
+  use iso_fortran_env, only: error_unit
   use NetCDF_read, only : check
   use netcdf
 
@@ -788,7 +791,7 @@ module NetCDF_def
     elseif (var_type == NF90_INT) then
       call CHECK(NF90_PUT_ATT(NCID=ncid,VARID=varid,NAME="_FillValue",VALUES=missing_value_int),var_name)
     else
-      write(0,'(a,i0,a)') "The variable '" // var_name // "' is defined as a type other than NF90_FLOAT or NF90_INT. Stopping..."
+      write(error_unit,'(a,i0,a)') "The variable '" // var_name // "' is defined as a type other than NF90_FLOAT or NF90_INT. Stopping..."
       error stop "Variable defined as a type other than NF90_FLOAT or NF90_INT."
     end if
 
@@ -866,6 +869,7 @@ module NetCDF_put
 end module NetCDF_put
 
 module data_qc
+  use iso_fortran_env, only: error_unit
   use scm_kinds, only : sp, dp, qp
   use NetCDF_read, only: missing_value, missing_value_int
 
@@ -932,7 +936,7 @@ module data_qc
       set_var = input
     else
       if (req) then
-        write(0,'(a,i0,a)') "The variable '" // input_name // "' in the case data file had missing data, but it is required for the given physics configuration. Stopping..."
+        write(error_unit,'(a,i0,a)') "The variable '" // input_name // "' in the case data file had missing data, but it is required for the given physics configuration. Stopping..."
         error stop "Variable in the case data file had missing data, but it is required for the given physics configuration."
       end if
     end if
@@ -952,7 +956,7 @@ module data_qc
       set_var = input
     else
       if (req) then
-        write(0,'(a,i0,a)') "The variable '" // input_name // "' in the case data file had missing data, but it is required for the given physics configuration. Stopping..."
+        write(error_unit,'(a,i0,a)') "The variable '" // input_name // "' in the case data file had missing data, but it is required for the given physics configuration. Stopping..."
         error stop "The variable in the case data file had missing data, but it is required for the given physics configuration"
       end if
     end if
@@ -972,7 +976,7 @@ module data_qc
       set_var = input
     else
       if (req) then
-        write(0,'(a,i0,a)') "The variable '" // input_name // "' in the case data file had missing data, but it is required for the given physics configuration. Stopping..."
+        write(error_unit,'(a,i0,a)') "The variable '" // input_name // "' in the case data file had missing data, but it is required for the given physics configuration. Stopping..."
         error stop "The variable in the case data file had missing data, but it is required for the given physics configuration"
       end if
     end if
@@ -992,7 +996,7 @@ module data_qc
       set_var = input
     else
       if (req) then
-        write(0,'(a,i0,a)') "The variable '" // input_name // "' in the case data file had missing data, but it is required for the given physics configuration. Stopping..."
+        write(error_unit,'(a,i0,a)') "The variable '" // input_name // "' in the case data file had missing data, but it is required for the given physics configuration. Stopping..."
         error stop "The variable in the case data file had missing data, but it is required for the given physics configuration"
       end if
     end if

--- a/scm/src/scm_vgrid.F90
+++ b/scm/src/scm_vgrid.F90
@@ -3,6 +3,7 @@
 
 module scm_vgrid
 
+use iso_fortran_env, only: error_unit
 use scm_kinds, only: sp, dp, qp, kind_scm_dp, kind_scm_sp
 use scm_physical_constants, only : con_cp, con_rocp, con_fvirt, con_g, con_rd
 
@@ -103,7 +104,7 @@ subroutine get_FV3_vgrid(scm_input, scm_state)
         !> - Open the appropriate file.
         open(unit=1, file=scm_state%vert_coord_file, status='old', action='read', iostat=ierr)
         if(ierr /= 0) then
-          write(*,*) 'There was an error opening the file ', scm_state%vert_coord_file, ' in the run directory. &
+          write(error_unit,*) 'There was an error opening the file ', scm_state%vert_coord_file, ' in the run directory. &
             &Error code = ',ierr
           error stop
         endif
@@ -117,7 +118,7 @@ subroutine get_FV3_vgrid(scm_input, scm_state)
         !> - The first line contains the number of coefficients and number of levels
         read(1,*) dummy, n_levels_file
         if (n_levels_file /= scm_state%n_levels) then
-          write(*,*) 'There is a mismatch in the number of levels expected and the number of coefficients supplied in the file ',scm_state%vert_coord_file
+          write(error_unit,*) 'There is a mismatch in the number of levels expected and the number of coefficients supplied in the file ',scm_state%vert_coord_file
           error stop
         end if
         !> - Read in the coefficient data.
@@ -1585,7 +1586,7 @@ subroutine check_eta_levels(ak, bk)
          write(*,'(I4, F13.5, F13.5, F11.2)') k, ak(k), bk(k), ak(k) + bk(k)*1000.E2
       enddo
    endif
-   write(*,*) 'FV3 check_eta_levels: ak/bk pairs do not provide a monotonic vertical coordinate'
+   write(error_unit,*) 'FV3 check_eta_levels: ak/bk pairs do not provide a monotonic vertical coordinate'
    error stop
  endif
 


### PR DESCRIPTION
SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES:
 - Using modern Fortran practices by using the `iso_fortran_env` `error_unit` when writing output that is a warning or error. The `run_scm.py` python script captures this as `stderr` output and in the future the script can better handle this information.

TESTS CONDUCTED: built with GNU modules on Derecho

NOTE: Do the changes to `CCPP_typedefs.F90` need to be also PR'ed elsewhere? 
