### PR TITLE
NSST initialization changes

### DIFF
--- a/ccpp/physics_namelists/input_GFS_v17_p8_ugwpv1.nml
+++ b/ccpp/physics_namelists/input_GFS_v17_p8_ugwpv1.nml
@@ -93,7 +93,7 @@
   iopt_tbot    = 2
   iopt_stc     = 3
   debug        = .false.
-  nstf_name    = 2,0,0,0,0
+  nstf_name    = 2,1,0,0,0
   nst_anl      = .true.
   psautco      = 0.0008,0.0005
   prautco      = 0.00015,0.00015

--- a/ccpp/physics_namelists/input_GFS_v17_p8_ugwpv1_ps.nml
+++ b/ccpp/physics_namelists/input_GFS_v17_p8_ugwpv1_ps.nml
@@ -93,7 +93,7 @@
   iopt_tbot    = 2
   iopt_stc     = 3
   debug        = .false.
-  nstf_name    = 2,0,0,0,0
+  nstf_name    = 2,1,0,0,0
   nst_anl      = .true.
   psautco      = 0.0008,0.0005
   prautco      = 0.00015,0.00015

--- a/ccpp/physics_namelists/input_RAP.nml
+++ b/ccpp/physics_namelists/input_RAP.nml
@@ -78,7 +78,7 @@
   debug        = .false.
   oz_phys      = .false.
   oz_phys_2015 = .true.
-  nstf_name    = 2,0,0,0,0
+  nstf_name    = 2,1,0,0,0
   nst_anl      = .true.
   lkm          = 0
   psautco      = 0.0008,0.0005

--- a/scm/etc/case_config/DYNAMO_NSA3a.nml
+++ b/scm/etc/case_config/DYNAMO_NSA3a.nml
@@ -3,6 +3,7 @@ case_name = 'DYNAMO_NSA3a',
 input_type = 1
 lsm_ics = .false.,
 do_spinup = .false.,
+do_sst_initialize_only = .false.
 spinup_timesteps = 0,
 reference_profile_choice = 2,
 column_area = 1.45E8,

--- a/scm/src/scm_forcing.F90
+++ b/scm/src/scm_forcing.F90
@@ -326,7 +326,7 @@ subroutine interpolate_forcing(scm_input, scm_state, in_spinup)
           end do
         end if
 
-        if (scm_state%surface_thermo_control == 0 .or. scm_state%surface_thermo_control == 1 .or. scm_state%surface_thermo_control == 2 .and. .not. scm_state%do_sst_initialize_only) then
+        if (scm_state%surface_thermo_control == 0 .or. scm_state%surface_thermo_control == 1 .or. scm_state%surface_thermo_control == 2 .and. (.not. scm_state%do_sst_initialize_only)) then
           !skin temperature is needed if surface fluxes are specified (for calculating bulk Richardson number in the specified surface flux scheme) and for simple ocean scheme
           do i=1, scm_state%n_cols
             scm_state%T_surf(i) = scm_input%input_T_surf(scm_input%input_ntimes)

--- a/scm/src/scm_forcing.F90
+++ b/scm/src/scm_forcing.F90
@@ -144,7 +144,9 @@ subroutine interpolate_forcing(scm_input, scm_state, in_spinup)
 
           !>  - Set the surface parameters to the last available data.
           scm_state%pres_surf(i) = scm_input%input_pres_surf(scm_input%input_ntimes)
-          scm_state%T_surf(i) = scm_input%input_T_surf(scm_input%input_ntimes)
+          if (.not. scm_state%do_sst_initialize_only) then
+            scm_state%T_surf(i) = scm_input%input_T_surf(scm_input%input_ntimes)
+          end if
           scm_state%sh_flux(i) = scm_input%input_sh_flux_sfc_kin(scm_input%input_ntimes)
           scm_state%lh_flux(i) = scm_input%input_lh_flux_sfc_kin(scm_input%input_ntimes)
         end do
@@ -324,7 +326,7 @@ subroutine interpolate_forcing(scm_input, scm_state, in_spinup)
           end do
         end if
 
-        if (scm_state%surface_thermo_control == 0 .or. scm_state%surface_thermo_control == 1 .or. scm_state%surface_thermo_control == 2) then
+        if (scm_state%surface_thermo_control == 0 .or. scm_state%surface_thermo_control == 1 .or. scm_state%surface_thermo_control == 2 .and. .not. scm_state%do_sst_initialize_only) then
           !skin temperature is needed if surface fluxes are specified (for calculating bulk Richardson number in the specified surface flux scheme) and for simple ocean scheme
           do i=1, scm_state%n_cols
             scm_state%T_surf(i) = scm_input%input_T_surf(scm_input%input_ntimes)
@@ -479,7 +481,9 @@ subroutine interpolate_forcing(scm_input, scm_state, in_spinup)
         !>  - Interpolate the surface parameters in time.
         scm_state%pres_surf(i) = (1.0 - lifrac)*scm_input%input_pres_surf(low_t_index) + &
           lifrac*scm_input%input_pres_surf(low_t_index+1)
-        scm_state%T_surf(i) = (1.0 - lifrac)*scm_input%input_T_surf(low_t_index) + lifrac*scm_input%input_T_surf(low_t_index+1)
+        if (.not. scm_state%do_sst_initialize_only .or. scm_state%model_time == 0.0) then
+          scm_state%T_surf(i) = (1.0 - lifrac)*scm_input%input_T_surf(low_t_index) + lifrac*scm_input%input_T_surf(low_t_index+1)
+        end if
         scm_state%sh_flux(i) = (1.0 - lifrac)*scm_input%input_sh_flux_sfc_kin(low_t_index) + &
           lifrac*scm_input%input_sh_flux_sfc_kin(low_t_index+1)
         scm_state%lh_flux(i) = (1.0 - lifrac)*scm_input%input_lh_flux_sfc_kin(low_t_index) + &
@@ -701,8 +705,8 @@ subroutine interpolate_forcing(scm_input, scm_state, in_spinup)
           scm_state%dT_dt_rad(i,:) = (1.0 - lifrac)*dT_dt_rad_bracket(1,:) + lifrac*dT_dt_rad_bracket(2,:)
         end do
       end if
-
-      if (scm_state%surface_thermo_control == 0 .or. scm_state%surface_thermo_control == 1 .or. scm_state%surface_thermo_control == 2) then
+        
+      if (scm_state%surface_thermo_control == 0 .or. scm_state%surface_thermo_control == 1 .or. scm_state%surface_thermo_control == 2 .and. (.not. scm_state%do_sst_initialize_only .or. scm_state%model_time == 0.0)) then
         !skin temperature is needed if surface fluxes are specified (for calculating bulk Richardson number in the specified surface flux scheme) and for simple ocean scheme
         do i=1, scm_state%n_cols
           scm_state%T_surf(i) = (1.0 - lifrac)*scm_input%input_T_surf(low_t_index) + lifrac*scm_input%input_T_surf(low_t_index+1)

--- a/scm/src/scm_input.F90
+++ b/scm/src/scm_input.F90
@@ -63,6 +63,7 @@ subroutine get_config_nml(scm_state)
   logical              :: model_ics !<  true means have land info too
   logical              :: lsm_ics !< true when LSM initial conditions are included (but not all ICs from another model)
   logical              :: do_spinup
+  logical              :: do_sst_initialize_only
   integer              :: reference_profile_choice !< 1: McClatchey profile, 2: mid-latitude summer standard atmosphere
   integer              :: year, month, day, hour, min
   real(kind=dp)        :: column_area
@@ -80,7 +81,7 @@ subroutine get_config_nml(scm_state)
 
   NAMELIST /case_config/ npz_type, vert_coord_file, case_name, dt, runtime, runtime_mult, n_itt_out, n_itt_diag, &
     n_levels, output_dir, thermo_forcing_type, model_ics, &
-    lsm_ics, do_spinup, C_RES, spinup_timesteps, mom_forcing_type, relax_time, sfc_type, sfc_flux_spec, &
+    lsm_ics, do_spinup, do_sst_initialize_only, C_RES, spinup_timesteps, mom_forcing_type, relax_time, sfc_type, sfc_flux_spec, &
     sfc_roughness_length_cm, reference_profile_choice, year, month, day, hour, min, &
     column_area, input_type
 
@@ -116,6 +117,7 @@ subroutine get_config_nml(scm_state)
   model_ics = .false.
   lsm_ics = .false.
   do_spinup = .false.
+  do_sst_initialize_only = .false.
   reference_profile_choice = 1
   year = 2006
   month = 1
@@ -200,6 +202,7 @@ subroutine get_config_nml(scm_state)
   scm_state%model_ics = model_ics
   scm_state%lsm_ics = lsm_ics
   scm_state%do_spinup = do_spinup
+  scm_state%do_sst_initialize_only = do_sst_initialize_only
   scm_state%reference_profile_choice = reference_profile_choice
   scm_state%relax_time = relax_time
   scm_state%input_type = input_type

--- a/scm/src/scm_type_defs.F90
+++ b/scm/src/scm_type_defs.F90
@@ -1333,12 +1333,16 @@ module scm_type_defs
           physics%Sfcprop%xs(i)      = real_zero
           physics%Sfcprop%xu(i)      = real_zero
           physics%Sfcprop%xv(i)      = real_zero
-          physics%Sfcprop%xz(i)      = 30.0_dp
+          physics%Sfcprop%xz(i)      = 20.0_dp
           physics%Sfcprop%zm(i)      = real_zero
           physics%Sfcprop%xtts(i)    = real_zero
           physics%Sfcprop%xzts(i)    = real_zero
           physics%Sfcprop%d_conv(i)  = real_zero
-          physics%Sfcprop%ifd(i)     = real_zero
+          if (scm_state%sfc_type(i) == 0) then
+            physics%Sfcprop%ifd(i)     = real_one
+          else
+            physics%Sfcprop%ifd(i)     = real_zero
+          endif
           physics%Sfcprop%dt_cool(i) = real_zero
           physics%Sfcprop%qrain(i)   = real_zero
         elseif (physics%Model%nstf_name(2) == 0) then         ! nsst restart

--- a/scm/src/scm_type_defs.F90
+++ b/scm/src/scm_type_defs.F90
@@ -104,6 +104,7 @@ module scm_type_defs
     logical                           :: model_ics !<  true means have land info too
     logical                           :: lsm_ics !< true when LSM initial conditions are included (but not all ICs from another model)
     logical                           :: do_spinup !< true when allowing the model to spin up before the "official" model integration starts
+    logical                           :: do_sst_initialize_only !< true when initializing SST only (and letting physics change SST during integration)
     integer                           :: input_type !< 0=> original DTC format, 1=> DEPHY-SCM format
     integer                           :: force_adv_T !< 0=> off, 1=> temperature, 2=> theta, 3=> thetal
     logical                           :: force_adv_qv !< true = on


### PR DESCRIPTION
Following discussion with @hertneky, this changes the following:

- Change the initial value of the ocean mixed layer depth (`xz`) to 20.0 m to match UFS
- Change `ifd` or the flag to turn on NSST to 1.0 if the surface is ocean; this only has an effect if prescribed surface fluxes are off and NSST is in the SDF and nstf_name(1) > 0.
-- if `ifd` starts as zero, NSST code can eventually set it to 1 if the model time is after 6 AM local time and ifd starts as 0, but during some cases, it was noticed that `ifd` wouldn't change to 1 (and therefore activate NSST) until the first "sunrise" after the model initializes (e.g. if a case started at noon, `ifd` wouldn't set itself to 1 until the next morning, even though NSST should be active immediately)
 - Set the nstf_name(2) value to 1 (NSST spin-up) in every SCM physics namelist to be consistent; the only chance for the SCM to not need spin-up is for a UFS-based case that has all of the NSST variables ready to be read in; **NOTE: for UFS cases needing to use NSST and when NSST variables are included in the case data file, the nstf_name(2) should be set to 0** (I don't think that this is documented anywhere. We can also probably make sure this happens programatically in the UFS_case_gen scripts. Added https://github.com/NCAR/ccpp-scm/issues/577 to address in the future).

New functionality needed for @bluefinweiwei:

- Add `do_sst_initialize_only` namelist variable (default value of F) to the case configuration namelist; if set to T, scm_state%T_surf (which gets pointed to by the `sea_surface_temperature` variable) only gets initialized from the case data file SST value. The default/original behavior is that when the `surface_forcing_temp` variable in the DEPHY-formatted case data file is set to `ts` (or any of the other options too, for that matter), the scm_state%T_surf gets updated from the case forcing file every timestep and physics has very little "authority" over this variable -- it may get changed during the physics call, but it will get reset when forcing occurs. The new behavior allows physics (including NSST) to change sea_surface_temperature how it wants to.