### PR TITLE
UFS-dev PR#258

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,10 @@
 	branch = main
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = main
+	#url = https://github.com/NCAR/ccpp-physics
+        #branch = main
+        url = https://github.com/grantfirl/ccpp-physics
+	branch = ufs-dev-PR258
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,10 +4,8 @@
 	branch = main
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	#url = https://github.com/NCAR/ccpp-physics
-        #branch = main
-        url = https://github.com/grantfirl/ccpp-physics
-	branch = ufs-dev-PR258
+	url = https://github.com/NCAR/ccpp-physics
+	branch = main
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules

--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -119,8 +119,6 @@ SCHEME_FILES = [
     'ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_cloud_mp.F90'          ,
     'ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_cloud_overlap.F90'     ,
     'ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_rrtmgp_post.F90'              ,
-    'ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_rad_reset.F90',
-    'ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_phys_reset.F90',
     'ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_1.F90'     ,
     'ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_interstitial_2.F90'     ,
     'ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/GFS_suite_stateout_reset.F90'     ,

--- a/ccpp/suites/suite_HAFS_v0_hwrf.xml
+++ b/ccpp/suites/suite_HAFS_v0_hwrf.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rrtmg_lw</scheme>
@@ -23,9 +22,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -60,6 +58,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_HAFS_v0_hwrf_ps.xml
+++ b/ccpp/suites/suite_HAFS_v0_hwrf_ps.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rrtmg_lw</scheme>
@@ -23,9 +22,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -41,6 +39,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_HAFS_v0_hwrf_thompson.xml
+++ b/ccpp/suites/suite_HAFS_v0_hwrf_thompson.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <!-- <scheme>sgscloud_radpre</scheme> -->
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <!-- <scheme>sgscloud_radpost</scheme> -->
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -62,6 +60,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_HAFS_v0_hwrf_thompson_ps.xml
+++ b/ccpp/suites/suite_HAFS_v0_hwrf_thompson_ps.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <!-- <scheme>sgscloud_radpre</scheme> -->
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <!-- <scheme>sgscloud_radpost</scheme> -->
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -43,6 +41,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>GFS_DCNV_generic_pre</scheme>
       <scheme>get_phi_fv3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v15p2.xml
+++ b/ccpp/suites/suite_SCM_GFS_v15p2.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -22,9 +21,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -59,6 +57,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v15p2_ACM_ps.xml
+++ b/ccpp/suites/suite_SCM_GFS_v15p2_ACM_ps.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -22,9 +21,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -40,6 +38,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v15p2_FA.xml
+++ b/ccpp/suites/suite_SCM_GFS_v15p2_FA.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -22,9 +21,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -59,6 +57,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v15p2_MYJ.xml
+++ b/ccpp/suites/suite_SCM_GFS_v15p2_MYJ.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -22,9 +21,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -59,6 +57,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v15p2_RRTMGP.xml
+++ b/ccpp/suites/suite_SCM_GFS_v15p2_RRTMGP.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmgp_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>GFS_rrtmgp_cloud_mp</scheme>
@@ -23,9 +22,8 @@
       <scheme>GFS_rrtmgp_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -60,6 +58,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v15p2_RRTMGP_ps.xml
+++ b/ccpp/suites/suite_SCM_GFS_v15p2_RRTMGP_ps.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmgp_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>GFS_rrtmgp_cloud_mp</scheme>
@@ -23,9 +22,8 @@
       <scheme>GFS_rrtmgp_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -41,6 +39,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v15p2_YSU_ps.xml
+++ b/ccpp/suites/suite_SCM_GFS_v15p2_YSU_ps.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -22,9 +21,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -40,6 +38,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v15p2_no_nsst.xml
+++ b/ccpp/suites/suite_SCM_GFS_v15p2_no_nsst.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -22,9 +21,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -57,6 +55,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v15p2_no_nsst_ps.xml
+++ b/ccpp/suites/suite_SCM_GFS_v15p2_no_nsst_ps.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -22,9 +21,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -40,6 +38,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v15p2_noahmp.xml
+++ b/ccpp/suites/suite_SCM_GFS_v15p2_noahmp.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -22,9 +21,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -59,6 +57,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v15p2_ntiedtke.xml
+++ b/ccpp/suites/suite_SCM_GFS_v15p2_ntiedtke.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -23,9 +22,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -60,6 +58,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v15p2_ntiedtke_ps.xml
+++ b/ccpp/suites/suite_SCM_GFS_v15p2_ntiedtke_ps.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -23,9 +22,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -41,6 +39,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v15p2_ps.xml
+++ b/ccpp/suites/suite_SCM_GFS_v15p2_ps.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -22,9 +21,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -40,6 +38,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v15p2_saYSU_ps.xml
+++ b/ccpp/suites/suite_SCM_GFS_v15p2_saYSU_ps.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -22,9 +21,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -40,6 +38,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v16.xml
+++ b/ccpp/suites/suite_SCM_GFS_v16.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -22,9 +21,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -59,6 +57,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v16_RRTMGP.xml
+++ b/ccpp/suites/suite_SCM_GFS_v16_RRTMGP.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmgp_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>GFS_rrtmgp_cloud_mp</scheme>
@@ -23,9 +22,8 @@
       <scheme>GFS_rrtmgp_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -60,6 +58,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v16_RRTMGP_ps.xml
+++ b/ccpp/suites/suite_SCM_GFS_v16_RRTMGP_ps.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmgp_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>GFS_rrtmgp_cloud_mp</scheme>
@@ -23,9 +22,8 @@
       <scheme>GFS_rrtmgp_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -41,6 +39,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v16_debug.xml
+++ b/ccpp/suites/suite_SCM_GFS_v16_debug.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -22,9 +21,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -59,6 +57,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v16_debug_ps.xml
+++ b/ccpp/suites/suite_SCM_GFS_v16_debug_ps.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -22,9 +21,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -40,6 +38,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v16_no_nsst.xml
+++ b/ccpp/suites/suite_SCM_GFS_v16_no_nsst.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -22,9 +21,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -57,6 +55,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v16_no_nsst_ps.xml
+++ b/ccpp/suites/suite_SCM_GFS_v16_no_nsst_ps.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -22,9 +21,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -40,6 +38,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v16_ps.xml
+++ b/ccpp/suites/suite_SCM_GFS_v16_ps.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -22,9 +21,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -40,6 +38,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v16_ugwpv1.xml
+++ b/ccpp/suites/suite_SCM_GFS_v16_ugwpv1.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -22,9 +21,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -59,6 +57,10 @@
       <scheme>ugwpv1_gsldrag_post</scheme>          
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v17_p8.xml
+++ b/ccpp/suites/suite_SCM_GFS_v17_p8.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -23,9 +22,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -60,6 +58,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v17_p8_c3.xml
+++ b/ccpp/suites/suite_SCM_GFS_v17_p8_c3.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -23,9 +22,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -60,6 +58,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v17_p8_c3_ps.xml
+++ b/ccpp/suites/suite_SCM_GFS_v17_p8_c3_ps.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -23,9 +22,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -41,6 +39,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v17_p8_ps.xml
+++ b/ccpp/suites/suite_SCM_GFS_v17_p8_ps.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -23,9 +22,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -41,6 +39,10 @@
       <scheme>unified_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v17_p8_ugwpv1.xml
+++ b/ccpp/suites/suite_SCM_GFS_v17_p8_ugwpv1.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -23,9 +22,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -60,6 +58,10 @@
       <scheme>ugwpv1_gsldrag_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v17_p8_ugwpv1_no_nsst.xml
+++ b/ccpp/suites/suite_SCM_GFS_v17_p8_ugwpv1_no_nsst.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -23,9 +22,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -58,6 +56,10 @@
       <scheme>ugwpv1_gsldrag_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v17_p8_ugwpv1_no_nsst_ps.xml
+++ b/ccpp/suites/suite_SCM_GFS_v17_p8_ugwpv1_no_nsst_ps.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -23,9 +22,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -41,6 +39,10 @@
       <scheme>ugwpv1_gsldrag_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GFS_v17_p8_ugwpv1_ps.xml
+++ b/ccpp/suites/suite_SCM_GFS_v17_p8_ugwpv1_ps.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -23,9 +22,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -41,6 +39,10 @@
       <scheme>ugwpv1_gsldrag_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GSD_v1.xml
+++ b/ccpp/suites/suite_SCM_GSD_v1.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="physics_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -59,6 +57,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GSD_v1_ps.xml
+++ b/ccpp/suites/suite_SCM_GSD_v1_ps.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -41,6 +39,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GSD_v1nssl.xml
+++ b/ccpp/suites/suite_SCM_GSD_v1nssl.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -59,6 +57,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_GSD_v1nssl_ps.xml
+++ b/ccpp/suites/suite_SCM_GSD_v1nssl_ps.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -41,6 +39,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_HRRR.xml
+++ b/ccpp/suites/suite_SCM_HRRR.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -59,6 +57,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_HRRR_gf.xml
+++ b/ccpp/suites/suite_SCM_HRRR_gf.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -24,9 +23,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -57,6 +55,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_HRRR_gf_ps.xml
+++ b/ccpp/suites/suite_SCM_HRRR_gf_ps.xml
@@ -11,7 +11,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -24,9 +23,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -41,6 +39,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_HRRR_ps.xml
+++ b/ccpp/suites/suite_SCM_HRRR_ps.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -40,6 +38,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_RAP.xml
+++ b/ccpp/suites/suite_SCM_RAP.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -58,6 +56,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_RAP_ps.xml
+++ b/ccpp/suites/suite_SCM_RAP_ps.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -40,6 +38,10 @@
       <scheme>drag_suite</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_RRFS_v1alpha.xml
+++ b/ccpp/suites/suite_SCM_RRFS_v1alpha.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -60,6 +58,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_RRFS_v1alpha_ps.xml
+++ b/ccpp/suites/suite_SCM_RRFS_v1alpha_ps.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -41,6 +39,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_RRFS_v1beta.xml
+++ b/ccpp/suites/suite_SCM_RRFS_v1beta.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -60,6 +58,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_RRFS_v1beta_no_nsst.xml
+++ b/ccpp/suites/suite_SCM_RRFS_v1beta_no_nsst.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -58,6 +56,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_RRFS_v1beta_no_nsst_ps.xml
+++ b/ccpp/suites/suite_SCM_RRFS_v1beta_no_nsst_ps.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -41,6 +39,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_RRFS_v1beta_ps.xml
+++ b/ccpp/suites/suite_SCM_RRFS_v1beta_ps.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -41,6 +39,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_RRFS_v1nssl.xml
+++ b/ccpp/suites/suite_SCM_RRFS_v1nssl.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -60,6 +58,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <!-- <scheme>GFS_suite_interstitial_3</scheme> -->

--- a/ccpp/suites/suite_SCM_WoFS_v0.xml
+++ b/ccpp/suites/suite_SCM_WoFS_v0.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -60,6 +58,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_MP_generic_pre</scheme>

--- a/ccpp/suites/suite_SCM_WoFS_v0_ps.xml
+++ b/ccpp/suites/suite_SCM_WoFS_v0_ps.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>sgscloud_radpre</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
@@ -25,9 +24,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -41,6 +39,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_MP_generic_pre</scheme>

--- a/ccpp/suites/suite_SCM_csawmg.xml
+++ b/ccpp/suites/suite_SCM_csawmg.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -23,9 +22,8 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>
@@ -60,6 +58,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/ccpp/suites/suite_SCM_csawmg_ps.xml
+++ b/ccpp/suites/suite_SCM_csawmg_ps.xml
@@ -24,7 +24,6 @@
   </group>
   <group name="phys_ps">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
       <scheme>get_prs_fv3</scheme>
       <scheme>GFS_suite_interstitial_1</scheme>

--- a/ccpp/suites/suite_SCM_csawmg_ps.xml
+++ b/ccpp/suites/suite_SCM_csawmg_ps.xml
@@ -12,7 +12,6 @@
   </group>
   <group name="radiation">
     <subcycle loop="1">
-      <scheme>GFS_suite_interstitial_rad_reset</scheme>
       <scheme>GFS_rrtmg_pre</scheme>
       <scheme>GFS_radiation_surface</scheme>
       <scheme>rad_sw_pre</scheme>
@@ -23,7 +22,7 @@
       <scheme>GFS_rrtmg_post</scheme>
     </subcycle>
   </group>
-  <group name="physics">
+  <group name="phys_ps">
     <subcycle loop="1">
       <scheme>GFS_suite_interstitial_phys_reset</scheme>
       <scheme>GFS_suite_stateout_reset</scheme>
@@ -41,6 +40,10 @@
       <scheme>cires_ugwp_post</scheme>
       <scheme>GFS_GWD_generic_post</scheme>
       <scheme>GFS_suite_stateout_update</scheme>
+    </subcycle>
+  </group>
+  <group name="phys_ts">
+    <subcycle loop="1">
       <scheme>GFS_photochemistry</scheme>
       <scheme>get_phi_fv3</scheme>
       <scheme>GFS_suite_interstitial_3</scheme>

--- a/scm/src/scm.F90
+++ b/scm/src/scm.F90
@@ -309,10 +309,27 @@ subroutine scm_main_sub()
     if (mod(physics%Model%kdt,physics%Model%nszero) == 1 .or. physics%Model%nszero == 1) then
       call physics%Diag%phys_zero (physics%Model)
     endif
-
-    call ccpp_physics_run(cdata, suite_name=trim(adjustl(scm_state%physics_suite_name)), ierr=ierr)
+    
+    !CCPP run phase
+    ! time_vary group doesn't have any run phase (omitted)
+    ! radiation group
+    call physics%Interstitial(1)%rad_reset(physics%Model)
+    call ccpp_physics_run(cdata, suite_name=trim(adjustl(scm_state%physics_suite_name)), group_name="radiation", ierr=ierr)
     if (ierr/=0) then
-        write(*,'(a,i0,a)') 'An error occurred in ccpp_physics_run: ' // trim(cdata%errmsg) // '. Exiting...'
+        write(*,'(a,i0,a)') 'An error occurred in ccpp_physics_run for group radiation: ' // trim(cdata%errmsg) // '. Exiting...'
+        error stop
+    end if
+    ! process-split physics
+    call physics%Interstitial(1)%phys_reset(physics%Model)
+    call ccpp_physics_run(cdata, suite_name=trim(adjustl(scm_state%physics_suite_name)), group_name="phys_ps", ierr=ierr)
+    if (ierr/=0) then
+        write(*,'(a,i0,a)') 'An error occurred in ccpp_physics_run for group phys_ps: ' // trim(cdata%errmsg) // '. Exiting...'
+        error stop
+    end if
+    ! time-split physics
+    call ccpp_physics_run(cdata, suite_name=trim(adjustl(scm_state%physics_suite_name)), group_name="phys_ts", ierr=ierr)
+    if (ierr/=0) then
+        write(*,'(a,i0,a)') 'An error occurred in ccpp_physics_run for group phys_ts: ' // trim(cdata%errmsg) // '. Exiting...'
         error stop
     end if
 

--- a/scm/src/scm_time_integration.F90
+++ b/scm/src/scm_time_integration.F90
@@ -154,11 +154,28 @@ subroutine do_time_step(scm_state, physics, cdata, in_spinup)
   if (mod(physics%Model%kdt,physics%Model%nszero) == 1 .or. physics%Model%nszero == 1) then
     call physics%Diag%phys_zero (physics%Model)
   endif
-
-  call ccpp_physics_run(cdata, suite_name=trim(adjustl(scm_state%physics_suite_name)), ierr=ierr)
+  
+  !CCPP run phase
+  ! time_vary group doesn't have any run phase (omitted)
+  ! radiation group
+  call physics%Interstitial(1)%rad_reset(physics%Model)
+  call ccpp_physics_run(cdata, suite_name=trim(adjustl(scm_state%physics_suite_name)), group_name="radiation", ierr=ierr)
   if (ierr/=0) then
-      write(*,'(a,i0,a)') 'An error occurred in ccpp_physics_run: ' // trim(cdata%errmsg) // '. Exiting...'
-      error stop trim(cdata%errmsg)
+      write(*,'(a,i0,a)') 'An error occurred in ccpp_physics_run for group radiation: ' // trim(cdata%errmsg) // '. Exiting...'
+      error stop
+  end if
+  ! process-split physics
+  call physics%Interstitial(1)%phys_reset(physics%Model)
+  call ccpp_physics_run(cdata, suite_name=trim(adjustl(scm_state%physics_suite_name)), group_name="phys_ps", ierr=ierr)
+  if (ierr/=0) then
+      write(*,'(a,i0,a)') 'An error occurred in ccpp_physics_run for group phys_ps: ' // trim(cdata%errmsg) // '. Exiting...'
+      error stop
+  end if
+  ! time-split physics
+  call ccpp_physics_run(cdata, suite_name=trim(adjustl(scm_state%physics_suite_name)), group_name="phys_ts", ierr=ierr)
+  if (ierr/=0) then
+      write(*,'(a,i0,a)') 'An error occurred in ccpp_physics_run for group phys_ts: ' // trim(cdata%errmsg) // '. Exiting...'
+      error stop
   end if
 
   call ccpp_physics_timestep_finalize(cdata, suite_name=trim(adjustl(scm_state%physics_suite_name)), ierr=ierr)


### PR DESCRIPTION
SOURCE: @grantfirl 

DESCRIPTION OF CHANGES:
  - updated all SDFs to remove interstitial "reset" schemes, introduce new `phys_ts` group for time-split schemes and `phys_ps` group for process-split schemes
  - remove reset schemes from ccpp_prebuild_config.py
  - change `ccpp_physics_run` calls in scm.F90 and scm_time_integration.F90 to call the interstitial%X_reset subroutines before radiation and phys_ps groups; use separate calls to `ccpp_physics_run` for radiation, phys_ps, and phys_ts groups

ISSUE: None

ASSOCIATED PRs:
<!-- NOTE: add the associated PR number after the # so Github can automatically link to them --->
 - https://github.com/NCAR/ccpp-physics/pull/1127

TESTS CONDUCTED: CI RTs


<!--
Delete the lines after this comment section if this is not a PR bringing in ufs/dev changes.
Otherwise delete the lines before this comment section.
NOTE: add the associated PR number after the # so Github can automatically link to them
--->


This PR catches the NCAR:main branch up with changes from the ufs-community:ufs/dev branch.

Associated ufs/dev PR:
- ufs-community/ccpp-physics#258

Associated fv3atm PR:
- NOAA-EMC/fv3atm#932

Associated NCAR PR:
 - NCAR/ccpp-physics#1127

---

REGRESSION TEST CHANGES: None
