### PR TITLE
ufs-community ccpp-physics PR260 memcheck fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
 	branch = main
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = main
+	url = https://github.com/scrasmussen/ccpp-physics
+	branch = ufs-dev-PR260-memcheck-fixes
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules

--- a/scm/src/GFS_typedefs.F90
+++ b/scm/src/GFS_typedefs.F90
@@ -29,7 +29,7 @@ module GFS_typedefs
    integer, parameter :: dfi_radar_max_intervals = 4 !< Number of radar-derived temperature tendency and/or convection suppression intervals. Do not change.
 
    real(kind=kind_phys), parameter :: limit_unspecified = 1e12 !< special constant for "namelist value was not provided" in radar-derived temperature tendency limit range
-   
+
    integer, parameter :: no_tracer = -99
 
 !> \section arg_table_GFS_typedefs
@@ -2485,7 +2485,6 @@ module GFS_typedefs
     allocate (Sfcprop%slope_save (IM))
     allocate (Sfcprop%shdmin     (IM))
     allocate (Sfcprop%shdmax     (IM))
-    allocate (Sfcprop%snoalb     (IM))
     allocate (Sfcprop%tg3        (IM))
     allocate (Sfcprop%vfrac      (IM))
     allocate (Sfcprop%vtype      (IM))
@@ -2505,7 +2504,6 @@ module GFS_typedefs
     Sfcprop%slope_save = zero
     Sfcprop%shdmin     = clear_val
     Sfcprop%shdmax     = clear_val
-    Sfcprop%snoalb     = clear_val
     Sfcprop%tg3        = clear_val
     Sfcprop%vfrac      = clear_val
     Sfcprop%vtype      = zero
@@ -4284,9 +4282,8 @@ module GFS_typedefs
 
 !--- read in the namelist
 #ifdef INTERNAL_FILE_NML
-    ! allocate required to work around GNU compiler bug 100886 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100886
     allocate (Model%input_nml_file, mold=input_nml_file)
-    Model%input_nml_file => input_nml_file
+    Model%input_nml_file = input_nml_file
     read(Model%input_nml_file, nml=gfs_physics_nml)
     ! Set length (number of lines) in namelist for internal reads
     Model%input_nml_file_length = size(Model%input_nml_file)
@@ -8419,12 +8416,12 @@ module GFS_typedefs
     endif
 
   end subroutine diag_phys_zero
-  
+
   function get_tracer_index (tracer_names, name)
 
     character(len=32), intent(in) :: tracer_names(:)
     character(len=*),  intent(in) :: name
-    
+
     !--- local variables
     integer :: get_tracer_index
     integer :: i


### PR DESCRIPTION
This PR puts the NCAR:main branch one PR behind the ufs-community:ufs/dev branch.

Associated ufs/dev PR:
- ufs-community/ccpp-physics#260

Associated fv3atm PR:
- NOAA-EMC/fv3atm#937

Associated NCAR PR:
 - NCAR/ccpp-physics#1133
