### PR TITLE
ufs-dev PR#259 CMake changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "ccpp-physics"]
 	path = ccpp/physics
 	url = https://github.com/scrasmussen/ccpp-physics
-	branch = ufs-dev-PR260-memcheck-fixes
+	branch = ufs-dev-PR259-CMake-changes
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "ccpp-physics"]
 	path = ccpp/physics
 	url = https://github.com/scrasmussen/ccpp-physics
-	branch = ufs-dev-PR259-CMake-changes
+	branch = ufs-dev-PR260-memcheck-fixes
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
 	branch = main
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = main
+	url = https://github.com/scrasmussen/ccpp-physics
+	branch = ufs-dev-PR260-memcheck-fixes
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules


### PR DESCRIPTION
NOTE: built on top of NCAR/ccpp-physics#1133 and NCAR/ccpp-scm#581 branches. 

Associated ufs/dev PR:
- ufs-community/ccpp-physics#259

Associated fv3atm PR:
- NOAA-EMC/fv3atm#940

Associated NCAR Framework PR:
 - NCAR/ccpp-framework#653

Associated NCAR PR:
 - NCAR/ccpp-physics#1134