### PR TITLE
Run Github Actions Only On NCAR/ccpp-scm

### DIFF
--- a/.github/workflows/build_and_push_docker_latest.yml
+++ b/.github/workflows/build_and_push_docker_latest.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   docker:
+    if: github.repository == 'NCAR/ccpp-scm'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/ci_scm_ccpp_prebuild.yml
+++ b/.github/workflows/ci_scm_ccpp_prebuild.yml
@@ -5,6 +5,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build-linux:
+    if: github.repository == 'NCAR/ccpp-scm'
 
     # The type of runner that the job will run on
     runs-on: ubuntu-latest


### PR DESCRIPTION
SOURCE: Soren Rasmussen, NSF NCAR

ISSUE: It seems that due to changes to NCAR policy, users will [get charged](https://github.com/settings/billing) for Github Actions run on their forked branch. This makes sure this doesn't happen.

DESCRIPTION OF CHANGES:
  - Only run Github Actions CI on upstream `NCAR/ccpp-scm` so users don't get charged for runner time
