### PR TITLE
UFS-dev PR#278

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
 	branch = main
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	url = https://github.com/grantfirl/ccpp-physics
-	branch = ufs-dev-PR278
+	url = https://github.com/NCAR/ccpp-physics
+	branch = main
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 [submodule "ccpp-physics"]
 	path = ccpp/physics
 	url = https://github.com/grantfirl/ccpp-physics
-	branch = ufs-dev-PR281
+	branch = ufs-dev-PR278
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules


### PR DESCRIPTION
SOURCE: @grantfirl

DESCRIPTION OF CHANGES:
  - updates SCM to work with https://github.com/ufs-community/ccpp-physics/pull/278 and https://github.com/ufs-community/ccpp-physics/pull/285 (no effect on SCM since only updates to gcycle, which the SCM doesn't use)

ISSUE: N/A

ASSOCIATED PRs:
https://github.com/NCAR/ccpp-physics/pull/1144

TESTS CONDUCTED: SCM RTs


This PR catches the NCAR:main branch up with changes from the ufs-community:ufs/dev branch.

Associated ufs/dev PR:
https://github.com/ufs-community/ufs-weather-model/pull/2723

Associated fv3atm PR:
https://github.com/NOAA-EMC/fv3atm/pull/960

Associated NCAR PR:
https://github.com/NCAR/ccpp-physics/pull/1144
https://github.com/ufs-community/ccpp-physics/pull/278
https://github.com/ufs-community/ccpp-physics/pull/285

---

REGRESSION TEST CHANGES: None
