### PR TITLE
Dockerfile Entrypoint Fix

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -142,4 +142,5 @@ if [ -n \"$PR_NUMBER\" ]; then \
   ./contrib/get_all_static_data.sh && \
   ./contrib/get_thompson_tables.sh; \
 fi && \
-cd /comsoftware/ccpp-scm/scm/bin"]
+cd /comsoftware/ccpp-scm/scm/bin && \
+exec sh"]


### PR DESCRIPTION
SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES:
  - added 'exec sh' to the entrypoint command of the Dockerfile so the container doesn't exit after starting. Cherry-picked the commit hash `6b561aa5c7d2f719aecb52c70275ce2a190ee8a8` from branch [release/public-v7](https://github.com/NCAR/ccpp-scm/tree/release/public-v7). Added that commit to get the Dockerfile working for the new upcoming v7.0.1 release and to push the new release to Dockerhub
 
