### PR TITLE
Add Ursa support

### DIFF
--- a/scm/doc/TechGuide/chap_quick.rst
+++ b/scm/doc/TechGuide/chap_quick.rst
@@ -155,7 +155,7 @@ contains the following set of libraries needed for building the SCM:
  - W3EMC (2.10.0) - GRIB decoder and encoder library
 
 Instructions for installing spack-stack can be found in the `spack-stack documentation <https://spack-stack.readthedocs.io/en/latest/>`__.
-Spack-stack is already installed and maintained on many HPC platforms, including NSF NCAR's Derecho, NOAA's Hera and
+Spack-stack is already installed and maintained on many HPC platforms, including NSF NCAR's Derecho, NOAA's Hera, Ursa, and
 Jet, and MSU's Orion.
 
 Compilers
@@ -192,7 +192,7 @@ the corresponding absolute path):
 View the contents of the directory to see if your machine/compiler
 combination is supported. As of this writing, modulefiles are provided
 for Intel and GNU compilers on the NCAR machine Derecho, the NOAA
-machines Hera and Jet, and the NOAA/MSU machine Orion. Loading these
+machines Hera, Ursa and Jet, and the NOAA/MSU machine Orion. Loading these
 modules will set up all the needed compilers, libraries, and other
 programs needed for building, as well as the python libraries needed for
 both building and running the SCM.

--- a/scm/etc/modules/ursa_gnu_spack_stack_1.9.1.lua
+++ b/scm/etc/modules/ursa_gnu_spack_stack_1.9.1.lua
@@ -3,7 +3,7 @@ This module loads libraries for building the CCPP Single-Column Model on
 the NOAA RDHPC machine Ursa using GNU 12.4
 ]])
 
-whatis([===[Loads libraries needed for building the CCPP SCM on Hera with GNU compilers ]===])
+whatis([===[Loads libraries needed for building the CCPP SCM on Ursa with GNU compilers ]===])
 
 prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.1/envs/ue-gcc-12.4.0/install/modulefiles/Core")
 

--- a/scm/etc/modules/ursa_gnu_spack_stack_1.9.1.lua
+++ b/scm/etc/modules/ursa_gnu_spack_stack_1.9.1.lua
@@ -1,0 +1,29 @@
+help([[
+This module loads libraries for building the CCPP Single-Column Model on
+the NOAA RDHPC machine Ursa using GNU 12.4
+]])
+
+whatis([===[Loads libraries needed for building the CCPP SCM on Hera with GNU compilers ]===])
+
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.1/envs/ue-gcc-12.4.0/install/modulefiles/Core")
+
+load("stack-gcc/12.4.0")
+load("stack-openmpi/4.1.6")
+load("stack-python/3.11.7")
+load("py-f90nml")
+load("py-netcdf4")
+load("cmake/3.30.2")
+
+load("netcdf-c/4.9.2")
+load("netcdf-fortran/4.6.1")
+load("bacio/2.4.1")
+load("sp/2.5.0")
+load("w3emc/2.10.0")
+load("esmf")
+
+setenv("CMAKE_C_COMPILER","mpicc")
+setenv("CMAKE_CXX_COMPILER","mpicxx")
+setenv("CMAKE_Fortran_COMPILER","mpif90")
+setenv("CMAKE_Platform","ursa.gnu")
+
+execute{cmd="source /scratch3/BMC/gmtb/ccpp-scm-software/spack-stack-1.9.1/bin/activate", modeA={"load"}}

--- a/scm/etc/modules/ursa_intel_spack_stack_1.9.1.lua
+++ b/scm/etc/modules/ursa_intel_spack_stack_1.9.1.lua
@@ -1,0 +1,29 @@
+help([[
+This module loads libraries for building the CCPP Single-Column Model on
+the NOAA RDHPC machine Ursa using Intel-2021.13.0
+]])
+
+whatis([===[Loads libraries needed for building the CCPP SCM on Ursa with Intel compilers ]===])
+
+prepend_path("MODULEPATH", "/contrib/spack-stack/spack-stack-1.9.1/envs/ue-oneapi-2024.2.1/install/modulefiles/Core")
+
+load("stack-oneapi/2024.2.1")
+load("stack-intel-oneapi-mpi/2021.13")
+load("stack-python/3.11.7")
+load("py-f90nml")
+load("py-netcdf4")
+load("cmake/3.30.2")
+
+load("netcdf-c/4.9.2")
+load("netcdf-fortran/4.6.1")
+load("bacio/2.4.1")
+load("sp/2.5.0")
+load("w3emc/2.10.0")
+load("esmf")
+
+setenv("CMAKE_C_COMPILER","mpiicc")
+setenv("CMAKE_CXX_COMPILER","mpiicpc")
+setenv("CMAKE_Fortran_COMPILER","mpiifort")
+setenv("CMAKE_Platform","ursa.intel")
+
+execute{cmd="source /scratch3/BMC/gmtb/ccpp-scm-software/spack-stack-1.9.1/bin/activate", modeA={"load"}}


### PR DESCRIPTION
SOURCE: Grant

DESCRIPTION OF CHANGES:
  - Added modulefiles for Ursa
  - Set up new python virtual environment in /scratch3/BMC/gmtb/ccpp-scm-software/spack-stack-1.9.1 (activated via normal module load)

ISSUE: 

ASSOCIATED PRs: None

TESTS CONDUCTED: Both modulefiles loaded on Ursa. Built, ran, and started analysis script.

REGRESSION TEST CHANGES: None
