### PR TITLE
Feature/rm physcons module

### DIFF
--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -24,10 +24,10 @@ VARIABLE_DEFINITION_FILES = [
     'ccpp/physics/physics/SFC_Models/Land/Noahmp/lnd_iau_mod.F90',
     'ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/module_ccpp_suite_simulator.F90',
     'scm/src/CCPP_typedefs.F90',
+    'scm/src/scm_physical_constants.F90',
     'scm/src/GFS_typedefs.F90',
     'scm/src/scm_kinds.F90',
     'scm/src/scm_type_defs.F90',
-    'scm/src/scm_physical_constants.F90',
     'scm/src/scm_utils.F90', #no definitions, but scm_type_defs.F90 uses a module from this file
     ]
 

--- a/scm/src/GFS_typedefs.F90
+++ b/scm/src/GFS_typedefs.F90
@@ -3335,7 +3335,7 @@ module GFS_typedefs
                                  communicator, ntasks, nthreads)
 
 !--- modules
-    use physcons,         only: con_rerth, con_pi, con_p0, rhowater
+    use scm_physical_constants, only: con_rerth, con_pi, con_p0, rhowater
     use mersenne_twister, only: random_setseed, random_number
     use GFS_ccpp_suite_sim_pre, only: load_ccpp_suite_sim
 !

--- a/scm/src/GFS_typedefs.meta
+++ b/scm/src/GFS_typedefs.meta
@@ -10271,7 +10271,7 @@
   name = GFS_typedefs
   type = module
   relative_path = ../../ccpp/physics/physics
-  dependencies = hooks/machine.F,hooks/physcons.F90
+  dependencies = hooks/machine.F
   dependencies = Radiation/RRTMG/radlw_param.f,Radiation/RRTMG/radsw_param.f
   dependencies = photochem/module_ozphys.F90,photochem/module_h2ophys.F90
   dependencies = SFC_Models/Land/Noahmp/lnd_iau_mod.F90

--- a/scm/src/scm_physical_constants.F90
+++ b/scm/src/scm_physical_constants.F90
@@ -64,5 +64,6 @@ public
   real(kind=dp),parameter:: con_thgni     = -38.15_dp        !< temperature the H.G.Nuc. ice starts
 
   ! --- constants from physcons.F90 ---
-  real(kind=dp),parameter:: decorr_con = 2.50_dp      !< ! Decorrelation length constant (km) for iovr = 4 or 5 and idcor = 0
+  real(kind=dp),parameter:: decorr_con = 2.50_dp      !< Decorrelation length constant (km) for iovr = 4 or 5 and idcor = 0
+  real(kind=dp),parameter:: qamin = 1.e-16_dp !< Minimum aerosol concentration
 end module scm_physical_constants

--- a/scm/src/scm_physical_constants.F90
+++ b/scm/src/scm_physical_constants.F90
@@ -63,4 +63,6 @@ public
   real(kind=dp),parameter:: con_solr_2008 = 1.3608e+3_dp     !< solar constant (\f$W/m^{2}\f$)-nasa-sorce Tim(2008)
   real(kind=dp),parameter:: con_thgni     = -38.15_dp        !< temperature the H.G.Nuc. ice starts
 
+  ! --- constants from physcons.F90 ---
+  real(kind=dp),parameter:: decorr_con = 2.50_dp      !< ! Decorrelation length constant (km) for iovr = 4 or 5 and idcor = 0
 end module scm_physical_constants

--- a/scm/src/scm_physical_constants.F90
+++ b/scm/src/scm_physical_constants.F90
@@ -10,7 +10,7 @@ public
 !! \htmlinclude scm_physical_constants.html
 !!
   real(kind=dp),parameter:: con_pi     =3.1415926535897931
-  
+
   real(kind=dp),parameter:: con_rerth  =6.3712e+6
   real(kind=dp),parameter:: con_g      =9.80665e+0
   real(kind=dp),parameter:: con_omega  =7.2921e-5
@@ -41,8 +41,9 @@ public
   real(kind=dp),parameter:: con_avgd   =6.0221415e23_dp
   real(kind=dp),parameter:: con_amd    =28.9644_dp                   !< molecular wght of dry air (\f$g/mol\f$)
   real(kind=dp),parameter:: con_amw    =18.0154_dp
+  real(kind=dp),parameter:: con_amo3   =47.9982_dp
   real(kind=dp),parameter:: karman     =0.4_dp
-  
+
   real(kind=dp),parameter:: cimin      =0.15
   !> minimum rain amount
   real(kind=dp),parameter:: rainmin    =1.e-13_dp
@@ -51,7 +52,7 @@ public
   real(kind=dp),parameter:: con_rhw0   =1022.0
   real(kind=dp),parameter:: con_sbc    =5.670400e-8
   real(kind=dp),parameter:: con_tice   =2.7120e+2
-  
+
   real(kind=dp),parameter:: rhowater   =1000._dp
   real(kind=dp),parameter:: rholakeice = 0.917e3_dp          !< density of ice on lake (kg/m^3)
 

--- a/scm/src/scm_physical_constants.meta
+++ b/scm/src/scm_physical_constants.meta
@@ -314,6 +314,13 @@
   dimensions = ()
   type = real
   kind = kind_phys
+[con_amo3]
+  standard_name = molecular_weight_of_ozone
+  long_name = molecular weight of ozone
+  units = g mol-1
+  dimensions = ()
+  type = real
+  kind = kind_phys
 [decorr_con]
   standard_name = decorrelation_length_constant
   long_name = Decorrelation length constant (km) for iovr = 4 or 5 and idcor = 0

--- a/scm/src/scm_physical_constants.meta
+++ b/scm/src/scm_physical_constants.meta
@@ -321,3 +321,10 @@
   dimensions = ()
   type = real
   kind = kind_phys
+[qamin]
+  standard_name = minimum_aerosol_concentration
+  long_name = Minimum aerosol mass mixing ratio
+  units = kg kg-1
+  dimensions = ()
+  type = real
+  kind = kind_phys

--- a/scm/src/scm_physical_constants.meta
+++ b/scm/src/scm_physical_constants.meta
@@ -47,7 +47,7 @@
   units = kg kg-1
   dimensions = ()
   type = real
-  kind = kind_phys 
+  kind = kind_phys
 [con_epsm1]
   standard_name = ratio_of_dry_air_to_water_vapor_gas_constants_minus_one
   long_name = (rd/rv) - 1
@@ -311,6 +311,13 @@
   standard_name = molecular_weight_of_water_vapor
   long_name = molecular weight of water vapor
   units = g mol-1
+  dimensions = ()
+  type = real
+  kind = kind_phys
+[decorr_con]
+  standard_name = decorrelation_length_constant
+  long_name = Decorrelation length constant (km) for iovr = 4 or 5 and idcor = 0
+  units = km
   dimensions = ()
   type = real
   kind = kind_phys

--- a/scm/src/scm_setup.F90
+++ b/scm/src/scm_setup.F90
@@ -295,7 +295,7 @@ subroutine GFS_suite_setup (Model, Statein, Stateout, Sfcprop,                  
                                  GFS_tbd_type,      GFS_cldprop_type,    &
                                  GFS_radtend_type,  GFS_diag_type
   use CCPP_typedefs,       only: GFS_interstitial_type
-  use physcons,            only: pi => con_pi
+  use scm_physical_constants, only: pi => con_pi
 
 
   !use cldwat2m_micro,      only: ini_micro
@@ -410,7 +410,7 @@ end subroutine GFS_suite_setup
 !------------------
 subroutine GFS_grid_populate (Grid, xlon, xlat, area)
   use machine,             only: kind_phys
-  use physcons,            only: pi => con_pi
+  use scm_physical_constants, only: pi => con_pi
   use GFS_typedefs,        only: GFS_grid_type
 
   implicit none


### PR DESCRIPTION
SOURCE: Soren Rasmussen, NCAR

DESCRIPTION OF CHANGES:
  - Removing physcons module to be inline with the CCPP way of handling constants and variables.
 
ASSOCIATED PRs:
<!-- NOTE: add the associated PR number after the # so Github can automatically link to them --->
 - NCAR/ccpp-physics#1146

TESTS CONDUCTED: To be done, PR will be in draft until a comparison of the results of main and this PR has been done. Those plots will be added to the PR.

<!--
Delete the lines after this comment section if this is not a PR bringing in ufs/dev changes.
Otherwise delete the lines before this comment section.
NOTE: add the associated PR number after the # so Github can automatically link to them
--->


This PR catches the NCAR:main branch up with changes from the ufs-community:ufs/dev branch.

Associated ufs/dev PR:
- ufs-community/ccpp-physics#

Associated fv3atm PR:
- NOAA-EMC/fv3atm#

Associated NCAR PR:
 - NCAR/ccpp-physics#

---

REGRESSION TEST CHANGES: Enter NONE if not applicable. Otherwise, expected results changes, input data changes, changes to the software, etc.
