### PR TITLE
Test: arm_sgp_summer_1997_A SCM_WoFS_v0 CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
 	branch = main
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = main
+	url = https://github.com/scrasmussen/ccpp-physics
+	branch = bugfix/arm_WoFS/ccpp
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules


### PR DESCRIPTION
Not a fix yet, just demonstrating where the error is.

SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES:
  - NaN check right before where [the code is breaking](https://github.com/scrasmussen/ccpp-physics/blob/9aabedce43920127a47c378dca631b9b83313f50/physics/MP/NSSL/module_mp_nssl_2mom.F90#L10759)
```
IF( ssat0(mgs) .GT. 0. .OR. ssf(mgs) .GT. 0. ) GO TO 620
```

TESTS CONDUCTED: The PR CI is the test. It breaks on the following CI test
```
 | arm_sgp_summer_1997_A | SCM_WoFS_v0 | input_WoFS_v0.nml |
 ```