### PR TITLE
bugfix: CI fix in module_mp_nssl_2mom.F90

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
 	branch = main
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	url = https://github.com/scrasmussen/ccpp-physics
-	branch = bugfix/arm_sgp_summer_1997_A-SCM_WoFS_v0-CI
+	url = https://github.com/NCAR/ccpp-physics
+	branch = main
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
 	branch = main
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = main
+	url = https://github.com/scrasmussen/ccpp-physics
+	branch = bugfix/arm_sgp_summer_1997_A-SCM_WoFS_v0-CI
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules


### PR DESCRIPTION
SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES:
  - bugfix: initialize data so it is never NaN. Fixes bug in CI when running the `arm_sgp_summer_1997_A` case and `SCM_WoFS_v0` suite. See Issue NCAR/ccpp-physics#1155 for details
  
ISSUE: NCAR/ccpp-physics#1155

ASSOCIATED PRs:
 -  NCAR/ccpp-physics#1157

TESTS CONDUCTED: CI