### PR TITLE
UFS-dev PR#302

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,7 +7,7 @@
 	#url = https://github.com/NCAR/ccpp-physics
 	#branch = main
 	url = https://github.com/grantfirl/ccpp-physics
-	branch = ufs-dev-PR253
+	branch = ufs-dev-PR302
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,8 @@
 	branch = main
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	#branch = main
-	url = https://github.com/grantfirl/ccpp-physics
-	branch = ufs-dev-PR302
+	url = https://github.com/NCAR/ccpp-physics
+	branch = main
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules

--- a/scm/src/GFS_typedefs.meta
+++ b/scm/src/GFS_typedefs.meta
@@ -394,7 +394,7 @@
 [qgrs(:,:,index_of_updraft_velocity_in_tracer_concentration_array)]
   standard_name = prognostic_updraft_velocity_in_convection
   long_name = convective updraft velocity
-  units = frac
+  units = Pa s-1
   dimensions = (horizontal_dimension,vertical_layer_dimension)
   type = real
   kind = kind_phys
@@ -684,7 +684,7 @@
 [gq0(:,:,index_of_updraft_velocity_in_tracer_concentration_array)]
   standard_name = updraft_velocity_updated_by_physics
   long_name = convective updraft area fraction updated by physics
-  units = frac
+  units = Pa s-1
   dimensions = (horizontal_dimension,vertical_layer_dimension)
   type = real
   kind = kind_phys
@@ -9710,6 +9710,22 @@
   type = real
   kind = kind_phys
   active = (flag_for_diagnostics_3D .and. flag_for_nrl_2015_ozone_scheme)
+[dqv_dt_prd]
+  standard_name = water_vapor_tendency_due_to_production_and_loss_rate
+  long_name = water_vapor tendency due to production and loss rate
+  units = kg kg-1 s-1
+  dimensions = (horizontal_dimension,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  active = (flag_for_diagnostics_3D .and. flag_for_stratospheric_water_vapor_physics)
+[dqv_dt_qvmx]
+  standard_name = water_vapor_tendency_due_to_water_vapor_mixing_ratio
+  long_name = water_vapor tendency due to water_vapor mixing ratio
+  units = kg kg-1 s-1
+  dimensions = (horizontal_dimension,vertical_layer_dimension)
+  type = real
+  kind = kind_phys
+  active = (flag_for_diagnostics_3D .and. flag_for_stratospheric_water_vapor_physics)
 [refl_10cm]
   standard_name = radar_reflectivity_10cm
   long_name = instantaneous refl_10cm


### PR DESCRIPTION
SOURCE: @grantfirl 

DESCRIPTION OF CHANGES:
 - Changes in GFS_typedefs necessary to run with https://github.com/NCAR/ccpp-physics/pull/1156

ISSUE: None

ASSOCIATED PRs:
https://github.com/NCAR/ccpp-physics/pull/1156

TESTS CONDUCTED: Tested in UFS RTs already. SCM RTs expect some results to change.


This PR catches the NCAR:main branch up with changes from the ufs-community:ufs/dev branch.

Associated ufs/dev PR:
https://github.com/ufs-community/ccpp-physics/pull/302

Associated fv3atm PR:
https://github.com/NOAA-EMC/fv3atm/pull/990

Associated NCAR PR:
https://github.com/NCAR/ccpp-physics/pull/1156

---

REGRESSION TEST CHANGES: Expected saSAS result changes. Also, photochemical diagnostic tendencies will change, so any case with non-zero ozone (all except BOMEX) will change results. BOMEX cases may not change results even if the suite uses saSAS because convection is not triggered.