### PR TITLE
DRAFT: Update CI to download artifact (baselines) from previous run.

### DIFF
--- a/.github/workflows/ci_run_scm_rts.yml
+++ b/.github/workflows/ci_run_scm_rts.yml
@@ -45,6 +45,14 @@ jobs:
         openmpi-bin \
         libopenmpi-dev
 
+    - name: Download a single artifact
+      uses: actions/download-artifact@v5
+      with:
+        cd ${dir_bl}
+        name: rt-baselines-${{matrix.build-type}}
+        pwd
+        ls -l
+    
     # Python setup
     - name: Setup Python
       uses: actions/setup-python@v6


### PR DESCRIPTION
DESCRIPTION OF CHANGES:
Update regression test CI script to download artifact (baselines) from previous run, instead of downloading artifact from external server.
Work in progress.

@grantfirl @scrasmussen 
I opened this to kick off the testing of the download artifact step. I was trying this with a PR on my own fork, but there are no artifacts stored there (doh!), so I'm trying it here.
