### PR TITLE
Updating template for ufsatm name change

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,8 +26,8 @@ This PR catches the NCAR:main branch up with changes from the ufs-community:ufs/
 Associated ufs/dev PR:
 - ufs-community/ccpp-physics#
 
-Associated fv3atm PR:
-- NOAA-EMC/fv3atm#
+Associated ufsatm PR:
+- NOAA-EMC/ufsatm#
 
 Associated NCAR PR:
  - NCAR/ccpp-physics#


### PR DESCRIPTION
SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES:
  - Small name change to the pull request template to mirror the `ufsatm` name change.

ASSOCIATED PRs:
<!-- NOTE: add the associated PR number after the # so Github can automatically link to them --->
 - NCAR/ccpp-physics#1166

