### PR TITLE
Remove references to physcons module from SCM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,8 +6,10 @@
 	branch = feature/capgen-v1
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = scm/dev
+	# url = https://github.com/NCAR/ccpp-physics
+	# branch = scm/dev
+	url = https://github.com/scrasmussen/ccpp-physics
+	branch = scm-dev-rm-ccpp-physcons
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules

--- a/scm/src/GFS_typedefs.F90
+++ b/scm/src/GFS_typedefs.F90
@@ -3438,7 +3438,8 @@ module GFS_typedefs
                                  cny, gnx, gny, ak, bk, hydrostatic)
 
 !--- modules
-    use physcons,         only: con_rerth, con_pi, con_p0, rhowater
+    use scm_physical_constants, only: con_rerth, con_pi, con_p0, rhowater, &
+         con_rocp
     use mersenne_twister, only: random_setseed, random_number
     use GFS_ccpp_suite_sim_pre, only: load_ccpp_suite_sim
 !
@@ -5079,7 +5080,7 @@ module GFS_typedefs
     Model%sedi_semi        = sedi_semi
     Model%decfl            = decfl
     ! TEMPO expects do_sat_adj variable to exist, but SCM never calls so set to .false.
-    Model%do_sat_adj       = .false. 
+    Model%do_sat_adj       = .false.
     Model%nt_c_l           = nt_c_l
     Model%nt_c_o           = nt_c_o
     Model%av_i             = av_i
@@ -6064,7 +6065,8 @@ module GFS_typedefs
        endif
     else
        !--- Climatological ozone
-       err_message = Model%ozphys%load_o3clim('global_o3prdlos.f77',kozc)
+       err_message = Model%ozphys%load_o3clim('global_o3prdlos.f77',kozc, &
+            con_rocp)
     end if
 
     !--- NRL h2o photochemistry physics.

--- a/scm/src/scm_physical_constants.F90
+++ b/scm/src/scm_physical_constants.F90
@@ -11,7 +11,7 @@ public
 !!
   integer      ,parameter:: con_zero   =0
   real(kind=dp),parameter:: con_pi     =3.1415926535897931
-  
+
   real(kind=dp),parameter:: con_rerth  =6.3712e+6
   real(kind=dp),parameter:: con_g      =9.80665e+0
   real(kind=dp),parameter:: con_omega  =7.2921e-5
@@ -42,8 +42,9 @@ public
   real(kind=dp),parameter:: con_avgd   =6.0221415e23_dp
   real(kind=dp),parameter:: con_amd    =28.9644_dp                   !< molecular wght of dry air (\f$g/mol\f$)
   real(kind=dp),parameter:: con_amw    =18.0154_dp
+  real(kind=dp),parameter:: con_amo3   =47.9982_dp                   !< molecular wght of o3 (\f$g/mol\f$)
   real(kind=dp),parameter:: karman     =0.4_dp
-  
+
   real(kind=dp),parameter:: cimin      =0.15
   !> minimum rain amount
   real(kind=dp),parameter:: rainmin    =1.e-13_dp
@@ -52,7 +53,7 @@ public
   real(kind=dp),parameter:: con_rhw0   =1022.0
   real(kind=dp),parameter:: con_sbc    =5.670400e-8
   real(kind=dp),parameter:: con_tice   =2.7120e+2
-  
+
   real(kind=dp),parameter:: rhowater   =1000._dp
   real(kind=dp),parameter:: rholakeice = 0.917e3_dp          !< density of ice on lake (kg/m^3)
 
@@ -63,10 +64,28 @@ public
   real(kind=dp),parameter:: con_solr_2002 = 1.3660e+3_dp     !< solar constant (\f$W/m^{2}\f$)-Liu(2002)
   real(kind=dp),parameter:: con_solr_2008 = 1.3608e+3_dp     !< solar constant (\f$W/m^{2}\f$)-nasa-sorce Tim(2008)
   real(kind=dp),parameter:: con_thgni     = -38.15_dp        !< temperature the H.G.Nuc. ice starts
-  
+
   ! for gfdlmp v3
+  real(kind=dp), parameter:: con_rhoair_IFS = 1.0  ! reference air density (kg/m^3), ref: IFS
+  real(kind=dp), parameter:: con_rhosnow = 100.0   ! density of snow (kg/m^3)
+  real(kind=dp), parameter :: con_visd  = 1.717e-5 ! dynamics viscosity of air at 0 deg C and 1000 hPa (Mason, 1971) (kg/m/s)
+  real(kind=dp), parameter :: con_visk  = 1.35e-5  ! kinematic viscosity of air at 0 deg C  and 1000 hPa (Mason, 1971) (m^2/s)
+  real(kind=dp), parameter :: con_vdifu = 2.25e-5  ! diffusivity of water vapor in air at 0 deg C  and 1000 hPa (Mason, 1971) (m^2/s)
+  real(kind=dp), parameter :: con_tcond = 2.40e-2  ! thermal conductivity of air at 0 deg C  and 1000 hPa (Mason, 1971) (J/m/s/K)
+  real(kind=dp), parameter :: con_cdg   = 3.15121  ! drag coefficient of graupel (Locatelli and Hobbs, 1974)
+  real(kind=dp), parameter :: con_cdh   = 0.5      ! drag coefficient of hail (Heymsfield and Wright, 2014)
+  real(kind=dp), parameter :: con_rhocw = 1.0e3    ! density of cloud water (kg/m^3)
+  real(kind=dp), parameter :: con_rhoci = 9.17e2   ! density of cloud ice (kg/m^3)
+  real(kind=dp), parameter :: con_rhocr = 1.0e3    ! density of rain (Lin et al. 1983) (kg/m^3)
+  real(kind=dp), parameter :: con_rhocg = 4.0e2    ! density of graupel (Rutledge and Hobbs 1984) (kg/m^3)
+  real(kind=dp), parameter :: con_rhoch = 9.17e2   ! density of hail (Lin et al. 1983) (kg/m^3)
+  real(kind=dp), parameter :: con_qcmin = 1.0e-15  ! min value for cloud condensates (kg/kg)
+  real(kind=dp), parameter :: con_qfmin = 1.0e-8   ! min value for sedimentation (kg/kg)
   real(kind=dp), parameter :: con_one      = 1_dp
   real(kind=dp), parameter :: con_p001     = 0.001_dp
   real(kind=dp), parameter :: con_secinday = 86400._dp
 
+  ! --- constants from physcons.F90 ---
+  real(kind=dp),parameter:: con_decorr = 2.50_dp  !< Decorrelation length constant (km) for iovr = 4 or 5 and idcor = 0
+  real(kind=dp),parameter:: con_qamin = 1.e-16_dp !< Minimum aerosol concentration
 end module scm_physical_constants

--- a/scm/src/scm_physical_constants.meta
+++ b/scm/src/scm_physical_constants.meta
@@ -53,7 +53,7 @@
   units = kg kg-1
   dimensions = ()
   type = real
-  kind = dp 
+  kind = dp
 [con_epsm1]
   standard_name = ratio_of_dry_air_to_water_vapor_gas_constants_minus_one
   long_name = (rd/rv) - 1
@@ -338,6 +338,132 @@
   standard_name = seconds_in_a_day
   long_name = number of seconds in a day
   units = s
+  dimensions = ()
+  type = real
+  kind = dp
+[con_amo3]
+  standard_name = molecular_weight_of_ozone
+  long_name = molecular weight of ozone
+  units = g mol-1
+  dimensions = ()
+  type = real
+  kind = dp
+[con_decorr]
+  standard_name = decorrelation_length_constant
+  long_name = Decorrelation length constant (km) for iovr = 4 or 5 and idcor = 0
+  units = km
+  dimensions = ()
+  type = real
+  kind = dp
+[con_qamin]
+  standard_name = minimum_aerosol_concentration
+  long_name = Minimum aerosol mass mixing ratio
+  units = kg kg-1
+  dimensions = ()
+  type = real
+  kind = dp
+[con_rhoair_IFS]
+  standard_name = density_of_air_IFS
+  long_name = density of air IFS
+  units = kg m-3
+  dimensions = ()
+  type = real
+  kind = dp
+[con_rhosnow]
+  standard_name = density_of_snow
+  long_name = density of snow
+  units = kg m-3
+  dimensions = ()
+  type = real
+  kind = dp
+[con_visd]
+  standard_name = dynamic_viscosity_of_air
+  long_name = dynamic viscosity of air at 0 deg C and 1000 hPa (Mason, 1971)
+  units = kg m-1 s-1
+  dimensions = ()
+  type = real
+  kind = dp
+[con_visk]
+  standard_name = kinematic_viscosity_of_air
+  long_name = kinematic viscosity of air at 0 deg C and 1000 hPa (Mason, 1971)
+  units = m2 s-1
+  dimensions = ()
+  type = real
+  kind = dp
+[con_vdifu]
+  standard_name = diffusivity_of_water_vapor_in_air
+  long_name = diffusivity of water vapor in air at 0 deg C and 1000 hPa (Mason, 1971)
+  units = m2 s-1
+  dimensions = ()
+  type = real
+  kind = dp
+[con_tcond]
+  standard_name = thermal_conductivity_of_air
+  long_name = thermal conductivity of air at 0 deg C and 1000 hPa (Mason, 1971)
+  units = W m-1 K-1
+  dimensions = ()
+  type = real
+  kind = dp
+[con_cdg]
+  standard_name = drag_coefficient_of_graupel
+  long_name = drag coefficient of graupel (Locatelli and Hobbs, 1974)
+  units = 1
+  dimensions = ()
+  type = real
+  kind = dp
+[con_cdh]
+  standard_name = drag_coefficient_of_hail
+  long_name = drag coefficient of hail (Heymsfield and Wright, 2014)
+  units = 1
+  dimensions = ()
+  type = real
+  kind = dp
+[con_rhocw]
+  standard_name = density_of_cloud_water
+  long_name = density of cloud water
+  units = kg m-3
+  dimensions = ()
+  type = real
+  kind = dp
+[con_rhoci]
+  standard_name = density_of_cloud_ice
+  long_name = density of cloud ice
+  units = kg m-3
+  dimensions = ()
+  type = real
+  kind = dp
+[con_rhocr]
+  standard_name = density_of_rain
+  long_name = density of rain (Lin et al., 1983)
+  units = kg m-3
+  dimensions = ()
+  type = real
+  kind = dp
+[con_rhocg]
+  standard_name = density_of_graupel
+  long_name = density of graupel (Rutledge and Hobbs, 1984)
+  units = kg m-3
+  dimensions = ()
+  type = real
+  kind = dp
+[con_rhoch]
+  standard_name = density_of_hail
+  long_name = density of hail (Lin et al., 1983)
+  units = kg m-3
+  dimensions = ()
+  type = real
+  kind = dp
+[con_qcmin]
+  standard_name = minimum_mass_mixing_ratio_of_cloud_condensate
+  long_name = minimum value for cloud condensates
+  units = kg kg-1
+  dimensions = ()
+  type = real
+  kind = dp
+[con_qfmin]
+  standard_name = minimum_mass_mixing_ratio_for_sedimentation
+  long_name = minimum value for sedimentation
+  units = kg kg-1
   dimensions = ()
   type = real
   kind = dp

--- a/scm/src/scm_setup.F90
+++ b/scm/src/scm_setup.F90
@@ -294,7 +294,7 @@ subroutine GFS_suite_setup (Model, Statein, Stateout, Sfcprop,                  
                                  GFS_control_type,  GFS_grid_type,       &
                                  GFS_tbd_type,      GFS_cldprop_type,    &
                                  GFS_radtend_type,  GFS_diag_type
-  use physcons,            only: pi => con_pi
+  use scm_physical_constants, only: pi => con_pi
 
 
   !use cldwat2m_micro,      only: ini_micro
@@ -406,7 +406,7 @@ end subroutine GFS_suite_setup
 !------------------
 subroutine GFS_grid_populate (Grid, xlon, xlat, area)
   use machine,             only: kind_phys
-  use physcons,            only: pi => con_pi
+  use scm_physical_constants, only: pi => con_pi
   use GFS_typedefs,        only: GFS_grid_type
 
   implicit none


### PR DESCRIPTION
SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES:
  - Removes direct dependencies on the global physcons module from CCPP physics schemes.
  - Supplies physical constants through explicit CCPP arguments, with standard names, units, and metadata.
  - Makes each scheme’s required constants visible in its interface instead of relying on hidden module state.
  - Improves portability and reuse of physics schemes in different host models and configurations.
  - Simplifies dependency tracking, testing, and maintenance by centralizing ownership of physical constants in the host/CCPP framework.

ISSUE: #652 

TESTS CONDUCTED: 
 - builds on Derecho
 - [ufs-wm Derecho regression tests](https://github.com/scrasmussen/ufs-weather-model/blob/ufs-dev-rm-ccpp-physcons/tests/logs/RegressionTests_derecho.log)

RELATED PRs:

* SCM - NCAR/ccpp-scm#653
    * ccpp-physics - NCAR/ccpp-physics#1235 


* UFSWM - ufs-community/ufs-weather-model#3323
  * UFSATM - NOAA-EMC/ufsatm#1131
    * ccpp-physics - ufs-community/ccpp-physics#381
      * c3 - ufs-community/c3#4
      * MYNN-SFC - NCAR/MYNN-SFC#32