### PR TITLE
Add fortran-to-metadata comparison script 

### DIFF
--- a/.github/workflows/cmp_fortran_to_metadata.yml
+++ b/.github/workflows/cmp_fortran_to_metadata.yml
@@ -15,6 +15,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Initialize Submodules
+        run: |
+          git config --global --add safe.directory ${SCM_ROOT}
+          cd ${SCM_ROOT}
+          git submodule update --init --recursive
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/cmp_fortran_to_metadata.yml
+++ b/.github/workflows/cmp_fortran_to_metadata.yml
@@ -28,6 +28,5 @@ jobs:
 
       - name: Compare Fortran source files to CCPP metadata files
         run: |
-          cd ${SCM_ROOT}
           cp test/test_fortran_to_metadata.py .
           ./test_fortran_to_metadata.py

--- a/.github/workflows/cmp_fortran_to_metadata.yml
+++ b/.github/workflows/cmp_fortran_to_metadata.yml
@@ -1,0 +1,27 @@
+name: Run Capgen fortran to metadata comparision script
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      SCM_ROOT: ${{ github.workspace }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Compare Fortran source files to CCPP metadata files
+        run: |
+          cd ${SCM_ROOT}
+          cp test/test_fortran_to_metadata.py .
+          ./test_fortran_to_metadata.py

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
 	branch = develop
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = scm/dev
+	url = https://github.com/dustinswales/ccpp-physics
+	branch = bug/flake_metadata
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules

--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -43,9 +43,16 @@ TYPEDEFS_NEW_METADATA = {
         },
     'module_radsw_parameters' : {
         'module_radsw_parameters' : '',
+        'cmpfsw_type' : '',
+        'sfcfsw_type' : '',
+        'profsw_type' : '',
+        'topfsw_type' : '',
         },
     'module_radlw_parameters' : {
         'module_radlw_parameters' : '',
+        'sfcflw_type' : '',
+        'proflw_type' : '',
+        'topflw_type' : '',
         },
     'module_ozphys' : {
         'module_ozphys' : '',

--- a/test/test_fortran_to_metadata.py
+++ b/test/test_fortran_to_metadata.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+###############################################################################
+# Dependencies
+###############################################################################
+import argparse
+import os
+import sys
+# Using Prebuild
+sys.path.append('ccpp/config')
+from ccpp_prebuild_config import SCHEME_FILES, TYPEDEFS_NEW_METADATA, VARIABLE_DEFINITION_FILES
+# Using Capgen
+sys.path.append('ccpp/framework/scripts')
+from metadata_table import register_ddts
+
+###############################################################################
+# Argument list
+###############################################################################
+parser = argparse.ArgumentParser()
+
+###############################################################################
+# Main program
+###############################################################################
+def main():
+    # Get command line arguments (N/A)
+    args  = parser.parse_args()
+
+    #
+    script_dir = 'ccpp/framework/scripts/'
+    f2m_script = script_dir+'/ccpp_fortran_to_metadata.py'
+
+    # Create list of known DDTs (using prebuild config script)
+    ddts_prebuild = []
+    for ct, typedefs in enumerate(TYPEDEFS_NEW_METADATA):
+        for typedef in TYPEDEFS_NEW_METADATA[typedefs]:
+            ddts_prebuild.append(typedef)
+        # end for
+    # end for
+    #print(ddts_prebuild)
+
+    # Create list of known DDTs (using capgen register_ddts)
+    # ######################################################################## 
+    # ########################################################################
+    # DJS: It's hard to know how Capgen is implemented, but to find the DDTs,
+    #      we need names for all the source files (scheme and host). Here I
+    #      just used the files lists used by the CCPP prebuild configuration.
+    # ########################################################################
+    # ######################################################################## 
+    # First, convert source file suffixes from fortran to .meta
+    # Scheme files
+    scheme_metadata = []
+    for scheme_file in SCHEME_FILES:
+        scheme_metadata.append(os.path.splitext(scheme_file)[0]+'.meta')
+    # end for
+    # Host files
+    host_metadata = []
+    # DJS: The last file in VARIABLE_DEFINITION_FILES is not a valid CCPP metadata file. Omit.
+    nhost = len(VARIABLE_DEFINITION_FILES)
+    for host_file in VARIABLE_DEFINITION_FILES[0:nhost-1]:
+        host_metadata.append(os.path.splitext(host_file)[0]+'.meta')
+    # end for
+
+    # Finally, register the DDTs
+    # NOTE: This returns a list of (lowercase) ddt names.
+    ddts_capgen = register_ddts(scheme_metadata+host_metadata)
+    #print(ddts_capgen)
+
+    # Create string from DDT list.
+    init = True
+    known_ddts = ''
+    for ddt in ddts_prebuild:
+        if (init):
+            known_ddts = ddt
+            init = False
+        else:
+            known_ddts = known_ddts+','+ddt
+        # end if
+    # end for
+
+    #
+    # Run Fortran-to-metadata comparision script
+    #
+    # DJS: This fails if you use the known_ddts from Capgen, which are all lowercase.
+    error_count = 0
+    error_file  = []
+    com = f2m_script+' --ddt-names '+known_ddts+' '
+    for scheme_file in SCHEME_FILES:
+        result = os.system(com+scheme_file)
+        if (result != 0):
+            error_count = error_count + 1
+            error_file.append(scheme_file)
+        # end if
+    # end for
+
+    print('------------------------------------------------------------------------------------')
+    if (error_count == 0):
+        print("SUCCESS! All metadata and Fortran files are consistent")
+    else:
+        print("ERROR! There are differences between the metadata and Fortran source files")
+        print("      ",str(error_count)+' files have issues:')
+        for ierror in error_file:
+            print("        ",ierror)
+        # end for
+        print("   See messages above for more details")
+    # end if
+    print('------------------------------------------------------------------------------------')
+
+###############################################################################
+###############################################################################
+if __name__ == '__main__':
+    main()

--- a/test/test_fortran_to_metadata.py
+++ b/test/test_fortran_to_metadata.py
@@ -6,69 +6,37 @@
 import argparse
 import os
 import sys
-# Using Prebuild
 sys.path.append('ccpp/config')
 from ccpp_prebuild_config import SCHEME_FILES, TYPEDEFS_NEW_METADATA, VARIABLE_DEFINITION_FILES
-# Using Capgen
-sys.path.append('ccpp/framework/scripts')
-from metadata_table import register_ddts
-
-###############################################################################
-# Argument list
-###############################################################################
-parser = argparse.ArgumentParser()
 
 ###############################################################################
 # Main program
 ###############################################################################
 def main():
-    # Get command line arguments (N/A)
-    args  = parser.parse_args()
+    # This list of files is not compared since they are known to fail.
+    files_known_to_not_pass_test = [
+        'ccpp/physics/physics/MP/GFDL/fv_sat_adj.F90',
+        'ccpp/physics/physics/Radiation/RRTMG/rrtmg_lw_post.F90',
+        'ccpp/physics/physics/SFC_Layer/UFS/sfc_diff.f',
+        'ccpp/physics/physics/SFC_Models/Lake/CLM/clm_lake.f90',
+        'ccpp/physics/physics/smoke_dust/rrfs_smoke_wrapper.F90']
 
-    #
+    # Comparison script from framework
     script_dir = 'ccpp/framework/scripts/'
     f2m_script = script_dir+'/ccpp_fortran_to_metadata.py'
 
     # Create list of known DDTs (using prebuild config script)
-    ddts_prebuild = []
+    ddts = []
     for ct, typedefs in enumerate(TYPEDEFS_NEW_METADATA):
         for typedef in TYPEDEFS_NEW_METADATA[typedefs]:
-            ddts_prebuild.append(typedef)
+            ddts.append(typedef)
         # end for
     # end for
-    #print(ddts_prebuild)
-
-    # Create list of known DDTs (using capgen register_ddts)
-    # ######################################################################## 
-    # ########################################################################
-    # DJS: It's hard to know how Capgen is implemented, but to find the DDTs,
-    #      we need names for all the source files (scheme and host). Here I
-    #      just used the files lists used by the CCPP prebuild configuration.
-    # ########################################################################
-    # ######################################################################## 
-    # First, convert source file suffixes from fortran to .meta
-    # Scheme files
-    scheme_metadata = []
-    for scheme_file in SCHEME_FILES:
-        scheme_metadata.append(os.path.splitext(scheme_file)[0]+'.meta')
-    # end for
-    # Host files
-    host_metadata = []
-    # DJS: The last file in VARIABLE_DEFINITION_FILES is not a valid CCPP metadata file. Omit.
-    nhost = len(VARIABLE_DEFINITION_FILES)
-    for host_file in VARIABLE_DEFINITION_FILES[0:nhost-1]:
-        host_metadata.append(os.path.splitext(host_file)[0]+'.meta')
-    # end for
-
-    # Finally, register the DDTs
-    # NOTE: This returns a list of (lowercase) ddt names.
-    ddts_capgen = register_ddts(scheme_metadata+host_metadata)
-    #print(ddts_capgen)
 
     # Create string from DDT list.
     init = True
     known_ddts = ''
-    for ddt in ddts_prebuild:
+    for ddt in ddts:
         if (init):
             known_ddts = ddt
             init = False
@@ -77,24 +45,27 @@ def main():
         # end if
     # end for
 
-    #
     # Run Fortran-to-metadata comparision script
-    #
-    # DJS: This fails if you use the known_ddts from Capgen, which are all lowercase.
     error_count = 0
     error_file  = []
     com = f2m_script+' --ddt-names '+known_ddts+' '
     for scheme_file in SCHEME_FILES:
-        result = os.system(com+scheme_file)
-        if (result != 0):
-            error_count = error_count + 1
-            error_file.append(scheme_file)
+        if (scheme_file not in files_known_to_not_pass_test):
+            result = os.system(com+scheme_file)
+            if (result != 0):
+                error_count = error_count + 1
+                error_file.append(scheme_file)
+            # end if
+        else:
+            print("skipping ",scheme_file)
         # end if
     # end for
 
+    # Display results
     print('------------------------------------------------------------------------------------')
     if (error_count == 0):
         print("SUCCESS! All metadata and Fortran files are consistent")
+        sys.exit(0)
     else:
         print("ERROR! There are differences between the metadata and Fortran source files")
         print("      ",str(error_count)+' files have issues:')
@@ -102,6 +73,7 @@ def main():
             print("        ",ierror)
         # end for
         print("   See messages above for more details")
+        sys.exit(1)
     # end if
     print('------------------------------------------------------------------------------------')
 


### PR DESCRIPTION
SOURCE: Dustin Swales NOAA-GSL/DTC

DESCRIPTION OF CHANGES:
- Add new CI script that runs Capgens fortran-parser/metadata-comparison script as part of our regular CI tests on all CCPP physics source files.
- Test reports failure if inconsistencies are introduced.
- Address one inconsistencies (NOTE Most of these were addressed prevously in physics PRs [#205](https://github.com/ufs-community/ccpp-physics/pull/205) and [#248](https://github.com/ufs-community/ccpp-physics/pull/248)

Due to errors in the Capgen fortran parser, the comparison script is turned off for **five** source files. The parser error are documented in the ccpp-framework repository. 
https://github.com/NCAR/ccpp-framework/issues/588
https://github.com/NCAR/ccpp-framework/issues/747
https://github.com/NCAR/ccpp-framework/issues/757
https://github.com/NCAR/ccpp-framework/issues/746

REGRESSION TEST CHANGES: NONE
