### PR TITLE
fix: scm run script works on Derecho login node

### DIFF
--- a/scm/doc/TechGuide/chap_quick.rst
+++ b/scm/doc/TechGuide/chap_quick.rst
@@ -528,6 +528,12 @@ of tests with the following command:
 
   $ ./run_scm.py -f ../../test/rt_test_cases.py
 
+The ``run_scm.py`` script calls ``mpirun -np 1 ./scm``, but ``mpirun/mpiexec``
+is unavailable on some host machine's login nodes. For example Derecho
+defaults to call ``./scm``, but calling an MPI compiled executable without
+``mpirun/mpiexec`` is not supported by all MPI implementations, so this is not
+the default on all systems.
+
 To see the full list of available options, use the ``--help`` flag:
 
 .. code:: bash

--- a/scm/src/run_scm.py
+++ b/scm/src/run_scm.py
@@ -34,7 +34,10 @@ DEFAULT_BIN_DIR = 'scm/bin'
 
 # Default command string to run MPI apps (number of processes should be 1 since SCM is not set up to use more than 1 yet)
 DEFAULT_MPI_COMMAND = 'mpirun -np 1'
-
+# If running on Derecho, mpirun/mpiexec will not work from login nodes,
+#   defaulting to not use them
+if 'derecho' in os.environ.get('HOST', '').lower():
+    DEFAULT_MPI_COMMAND = ''
 
 # Copy executable to run directory if true (otherwise it will be linked)
 COPY_EXECUTABLE = False
@@ -467,7 +470,7 @@ class Experiment(object):
                 raise Exception(message)
             else:
                 case_nml['case_config']['runtime_mult'] = self._runtime_mult
-                    
+
         # If the number of levels is specified, set the namelist value
         if self._levels:
             case_nml['case_config']['n_levels'] = self._levels


### PR DESCRIPTION
SOURCE: Soren Rasmussen, NSF

DESCRIPTION OF CHANGES:
  - Updating run script to work from Derecho login node, updating documentation with reasoning
  - The ``run_scm.py`` script calls ``mpirun -np 1 ./scm``, but ``mpirun/mpiexec``
is unavailable on some host machine's login nodes. For example Derecho
defaults to call ``./scm``, but calling an MPI compiled executable without
``mpirun/mpiexec`` is not supported by all MPI implementations, so this is not
the default on all systems.

TESTS CONDUCTED: tested on Derecho login node