### PR TITLE
fix: Derecho spack stack 2.X wget fix

### DIFF
--- a/scm/etc/modules/derecho_gnu/2.1.0.lua
+++ b/scm/etc/modules/derecho_gnu/2.1.0.lua
@@ -5,7 +5,10 @@ the CISL machine Derecho (Cray) using GNU 13.3.1
 
 whatis([===[Loads spack-stack libraries needed for building the CCPP SCM on Derecho with GNU compilers]===])
 
-prepend_path("MODULEPATH","/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-2.1.0/envs/ue-gcc-13.3.1/modules/Core/")
+
+local spack_root = "/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-2.1.0/envs/ue-gcc-13.3.1/"
+prepend_path("MODULEPATH", pathJoin(spack_root, "modules/Core/"))
+prepend_path("LD_LIBRARY_PATH", pathJoin(spack_root, "install/gcc/13.3.1/openssl-3.4.1-a3zr655/lib64"))
 
 load("stack-gcc/13.3.1")
 load("stack-cray-mpich/8.1.32")
@@ -22,9 +25,8 @@ load("w3emc/2.13.0")
 load("py-f90nml/1.4.3")
 load("py-netcdf4/1.7.2")
 
-local bashStr = '/glade/u/apps/derecho/25.10/opt/view/bin/emacs -nw "$@"'
-local cshStr  = '/glade/u/apps/derecho/25.10/opt/view/bin/emacs -nw $*'
-set_shell_function("emacs", bashStr, cshStr)
+-- emacs not in gnu spack stack 2.1.0
+prepend_path("PATH", "/glade/u/apps/derecho/25.10/spack/opt/spack/emacs/30.2/gcc/12.5.0/azrq/bin")
 
 setenv("CMAKE_C_COMPILER","mpicc")
 setenv("CMAKE_CXX_COMPILER","mpicxx")

--- a/scm/etc/modules/derecho_intel/2.0.0.lua
+++ b/scm/etc/modules/derecho_intel/2.0.0.lua
@@ -6,7 +6,10 @@ the CISL machine Derecho (Cray) using Intel oneAPI 2025.2.1
 whatis([===[Loads spack-stack libraries needed for building the CCPP SCM on Derecho with Intel compilers]===])
 
 
-prepend_path("MODULEPATH","/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-2.0.0/envs/ue-oneapi-2025.2.1/modules/Core/")
+local spack_root = "/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-2.0.0/envs/ue-oneapi-2025.2.1"
+prepend_path("MODULEPATH", pathJoin(spack_root, "modules/Core/"))
+prepend_path("LD_LIBRARY_PATH", pathJoin(spack_root, "install/intel-oneapi-compilers/2025.2.1/openssl-3.4.1-oacbwdv/lib64/"))
+
 
 load("stack-intel-oneapi-compilers/2025.2.1")
 load("stack-cray-mpich/8.1.32")


### PR DESCRIPTION
SOURCE: Soren Rasmussen and Tracy Hertneky, NSF NCAR

DESCRIPTION OF CHANGES:
- spack stack 2.1 and 2.0 wget wasn't finding OPENSSL_3.2. library, this PR adds its path directly to `LD_LIBRARY_PATH`
- emacs is not in gnu spack stack 2.1, adding NCAR environment's emacs to PATH for better integration

TESTS CONDUCTED: ran the following and it now works
```
$ ml purge; ml derecho_gnu
$ wget --version
```