### PR TITLE
ccpp-physics PR: deploy-pages-upstream-only

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,10 @@
 	branch = develop
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = scm/dev
+	# url = https://github.com/NCAR/ccpp-physics
+	# branch = scm/dev
+	url = https://github.com/scrasmussen/ccpp-physics
+	branch = deploy-pages-upstream-only
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules


### PR DESCRIPTION
SOURCE: Soren Rasmussen, NSF NCAR

DESCRIPTION OF CHANGES:
  - Deploy CCPP-Physics Github pages from upstream repo only since it will fail when run from a fork
 
ISSUE:
 - When a fork updates their `main` branch, Github Actions will attempt to deploy ccpp-physic's github pages from that fork and [will fail](https://github.com/scrasmussen/ccpp-physics/actions/runs/27839556278/job/82395292765)