### PR TITLE
ufs-dev PR#377 RRFS smoke fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,10 +4,8 @@
 	branch = develop
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	url = https://github.com/scrasmussen/ccpp-physics
-	branch = ufs-dev-pr377
-	# url = https://github.com/NCAR/ccpp-physics
-	# branch = scm/dev
+	url = https://github.com/NCAR/ccpp-physics
+	branch = scm/dev
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,10 @@
 	branch = develop
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = scm/dev
+	url = https://github.com/scrasmussen/ccpp-physics
+	branch = ufs-dev-pr377
+	# url = https://github.com/NCAR/ccpp-physics
+	# branch = scm/dev
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules


### PR DESCRIPTION
This PR catches the NCAR:main branch up with changes from the ufs-community:ufs/dev branch.

Associated ufs/dev PR:
- ufs-community/ccpp-physics#377

Associated ufsatm PR:
- NOAA-EMC/ufsatm#1124

Associated ufs-weather-model PR:
- ufs-community/ufs-weather-model#3267

Associated NCAR PR:
 - NCAR/ccpp-physics#1230

---

REGRESSION TEST CHANGES: The SCM tests fail in the SCM Github CI for the GNU Debug dev build. I have confirmed though that this exact build works on Derecho, so this is more likely a corner case in the Github CI that needs to be fixed.