### PR TITLE
ufs-dev PR#353 tempo version 3 and ufs-dev PR#369 main sync

### DIFF
--- a/.github/workflows/run_scm_rts.yml
+++ b/.github/workflows/run_scm_rts.yml
@@ -14,6 +14,7 @@ jobs:
     if: github.repository == 'NCAR/ccpp-scm'
     strategy:
       fail-fast: false
+      max-parallel: 5
       matrix:
         fortran-compiler: [ifx, gfortran]#, nvfortran]
         build-type:       [Release, Debug]

--- a/.github/workflows/run_scm_rts.yml
+++ b/.github/workflows/run_scm_rts.yml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository == 'NCAR/ccpp-scm'
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 4
       matrix:
         fortran-compiler: [ifx, gfortran]#, nvfortran]
         build-type:       [Release, Debug]

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,10 @@
 	branch = develop
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	url = https://github.com/NCAR/ccpp-physics
-	branch = scm/dev
+	# url = https://github.com/NCAR/ccpp-physics
+	# branch = scm/dev
+	url = https://github.com/scrasmussen/ccpp-physics
+	branch = ufs-dev-pr353-tempo-v3
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,10 +4,8 @@
 	branch = develop
 [submodule "ccpp-physics"]
 	path = ccpp/physics
-	# url = https://github.com/NCAR/ccpp-physics
-	# branch = scm/dev
-	url = https://github.com/scrasmussen/ccpp-physics
-	branch = ufs-dev-pr353-tempo-v3
+	url = https://github.com/NCAR/ccpp-physics
+	branch = scm/dev
 [submodule "CMakeModules"]
 	path = CMakeModules
 	url = https://github.com/noaa-emc/CMakeModules

--- a/ccpp/config/ccpp_prebuild_config.py
+++ b/ccpp/config/ccpp_prebuild_config.py
@@ -21,7 +21,7 @@ VARIABLE_DEFINITION_FILES = [
     'ccpp/physics/physics/Radiation/RRTMG/radlw_param.f',
     'ccpp/physics/physics/photochem/module_ozphys.F90',
     'ccpp/physics/physics/photochem/module_h2ophys.F90',
-    'ccpp/physics/physics/MP/TEMPO/TEMPO/module_mp_tempo_params.F90',
+    'ccpp/physics/physics/MP/TEMPO/tempo_v3/src/module_mp_tempo_cfgs.F90',
     'ccpp/physics/physics/SFC_Models/Land/Noahmp/lnd_iau_mod.F90',
     'ccpp/physics/physics/Interstitials/UFS_SCM_NEPTUNE/module_ccpp_suite_simulator.F90',
     'scm/src/CCPP_typedefs.F90',
@@ -55,9 +55,9 @@ TYPEDEFS_NEW_METADATA = {
         'module_h2ophys' : '',
         'ty_h2ophys'     : '',
         },
-    'module_mp_tempo_params' : {
-        'module_mp_tempo_params' : '',
-        'ty_tempo_cfg'     : '',
+    'module_mp_tempo_cfgs' : {
+        'module_mp_tempo_cfgs' : '',
+        'ty_tempo_cfgs'        : '',
         },
     'land_iau_mod' : {
         'land_iau_mod' : '',
@@ -187,6 +187,7 @@ SCHEME_FILES = [
     'ccpp/physics/physics/MP/Thompson/mp_thompson.F90',
     'ccpp/physics/physics/MP/Thompson/mp_thompson_post.F90',
     'ccpp/physics/physics/MP/TEMPO/mp_tempo.F90',
+    'ccpp/physics/physics/MP/TEMPO/mp_tempo_condensation.F90',
     'ccpp/physics/physics/MP/TEMPO/mp_tempo_post.F90',
     'ccpp/physics/physics/PBL/HEDMF/hedmf.f',
     'ccpp/physics/physics/PBL/SHOC/moninshoc.f',

--- a/contrib/get_aerosol_climo.sh
+++ b/contrib/get_aerosol_climo.sh
@@ -10,7 +10,7 @@ print_help() {
     echo "    --help           Show this help message and exit."
 }
 
-verbose="-q"
+verbose="-v"
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in

--- a/contrib/get_aerosol_climo.sh
+++ b/contrib/get_aerosol_climo.sh
@@ -30,7 +30,7 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
-#set -ex
+set -ex
 
 # Directory where this script is located
 if [[ $(uname -s) == Darwin ]]; then
@@ -47,6 +47,7 @@ BASEDIR=$MYDIR/..
 # Change to directory containing the physics input data, download and extract archive
 data_files=("FV3_aeroclim1" "FV3_aeroclim2" "FV3_aeroclim3" "FV3_aeroclim_optics")
 
+mkdir -p $BASEDIR/scm/data/physics_input_data/
 cd $BASEDIR/scm/data/physics_input_data/
 for file in "${data_files[@]}"; do
     echo "Retrieving $file.tar.gz"

--- a/contrib/get_all_static_data.sh
+++ b/contrib/get_all_static_data.sh
@@ -11,6 +11,12 @@ print_help() {
 }
 
 verbose="-v"
+wget_options=(
+    --tries=10
+    --waitretry=10
+    --retry-connrefused
+    --retry-on-http-error=429,500,502,503,504
+)
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
@@ -51,7 +57,7 @@ for file in "${data_files[@]}"; do
     mkdir -p $BASEDIR/scm/data/$file
     cd $BASEDIR/scm/data/$file
     echo "Retrieving $file"
-    wget ${verbose} https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/${file}.tar.gz
+    wget ${verbose} "${wget_options[@]}" https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/${file}.tar.gz
     tar -xf ${file}.tar.gz
     rm -f ${file}.tar.gz
 done

--- a/contrib/get_all_static_data.sh
+++ b/contrib/get_all_static_data.sh
@@ -10,7 +10,7 @@ print_help() {
     echo "    --help           Show this help message and exit."
 }
 
-verbose="-q"
+verbose="-v"
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in

--- a/contrib/get_mg_inccn_data.sh
+++ b/contrib/get_mg_inccn_data.sh
@@ -11,6 +11,12 @@ print_help() {
 }
 
 verbose="-v"
+wget_options=(
+    --tries=10
+    --waitretry=10
+    --retry-connrefused
+    --retry-on-http-error=429,500,502,503,504
+)
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
@@ -46,7 +52,7 @@ BASEDIR=$MYDIR/..
 
 # Change to directory containing the physics input data, download and extract archive
 cd $BASEDIR/scm/data/physics_input_data/
-wget ${verbose} https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/MG_INCCN_data.tar.gz
+wget ${verbose} "${wget_options[@]}" https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/MG_INCCN_data.tar.gz
 tar -xvf MG_INCCN_data.tar.gz
 rm -f MG_INCCN_data.tar.gz
 cd $BASEDIR/

--- a/contrib/get_mg_inccn_data.sh
+++ b/contrib/get_mg_inccn_data.sh
@@ -10,7 +10,7 @@ print_help() {
     echo "    --help           Show this help message and exit."
 }
 
-verbose="-q"
+verbose="-v"
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in

--- a/contrib/get_rrtmgp_data.sh
+++ b/contrib/get_rrtmgp_data.sh
@@ -11,6 +11,12 @@ print_help() {
 }
 
 verbose="-v"
+wget_options=(
+    --tries=10
+    --waitretry=10
+    --retry-connrefused
+    --retry-on-http-error=429,500,502,503,504
+)
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
@@ -45,7 +51,7 @@ BASEDIR=$MYDIR/..
 
 # Change to directory containing the physics input data, download and extract archive
 cd $BASEDIR/scm/data/physics_input_data/
-wget ${verbose} https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/rrtmgp_data.tar.gz
+wget ${verbose} "${wget_options[@]}" https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/rrtmgp_data.tar.gz
 tar -xvzf rrtmgp_data.tar.gz
 rm -f rrtmgp_data.tar.gz
 cd $BASEDIR/

--- a/contrib/get_rrtmgp_data.sh
+++ b/contrib/get_rrtmgp_data.sh
@@ -10,7 +10,7 @@ print_help() {
     echo "    --help           Show this help message and exit."
 }
 
-verbose="-q"
+verbose="-v"
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in

--- a/contrib/get_tempo_data.sh
+++ b/contrib/get_tempo_data.sh
@@ -44,8 +44,26 @@ fi
 BASEDIR=$MYDIR/..
 
 # Change to directory containing the physics input data, download and extract archive
+mkdir -p $BASEDIR/scm/data/physics_input_data/
 cd $BASEDIR/scm/data/physics_input_data/
 wget ${verbose} https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/tempo_data.tar.gz
 tar -xvzf tempo_data.tar.gz
 rm -f tempo_data.tar.gz
+
+# The archive uses legacy MP_TEMPO_*.dat names; tempo_v3's Fortran source
+# (module_mp_tempo_cfgs.F90) hardcodes different filenames with no
+# host/namelist override, so symlink to what it actually looks for.
+#
+# qr_acr_qg_data_tempo_v3 -> HAILAWARE variant: workaround for an upstream
+# bug (see claude_bug_report.md) where initialize_arrays_qr_acr_qg() always
+# allocates the hail-aware-sized (nrhg=9) table regardless of hailaware_flag.
+ln -sf MP_TEMPO_HAILAWARE_QRacrQG.dat qr_acr_qg_data_tempo_v3
+ln -sf MP_TEMPO_QRacrQS.dat           qr_acr_qs_data_tempo_v3
+ln -sf MP_TEMPO_freezeH2O.dat         freeze_water_data_tempo_v3
+
+# ccn_activate.bin isn't in the downloaded archive at all -- it's small
+# (~35KB) and checked directly into the TEMPO submodule, so symlink it in
+# from there instead.
+ln -sf $BASEDIR/ccpp/physics/physics/MP/TEMPO/tempo_v3/tables/ccn_activate.bin ccn_activate.bin
+
 cd $BASEDIR/

--- a/contrib/get_tempo_data.sh
+++ b/contrib/get_tempo_data.sh
@@ -10,7 +10,7 @@ print_help() {
     echo "    --help           Show this help message and exit."
 }
 
-verbose="-q"
+verbose="-v"
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in

--- a/contrib/get_tempo_data.sh
+++ b/contrib/get_tempo_data.sh
@@ -11,6 +11,12 @@ print_help() {
 }
 
 verbose="-v"
+wget_options=(
+    --tries=10
+    --waitretry=10
+    --retry-connrefused
+    --retry-on-http-error=429,500,502,503,504
+)
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
@@ -46,7 +52,7 @@ BASEDIR=$MYDIR/..
 # Change to directory containing the physics input data, download and extract archive
 mkdir -p $BASEDIR/scm/data/physics_input_data/
 cd $BASEDIR/scm/data/physics_input_data/
-wget ${verbose} https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/tempo_v3_data.tar.gz
+wget ${verbose} "${wget_options[@]}" https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/tempo_v3_data.tar.gz
 tar -xvzf tempo_v3_data.tar.gz
 rm -f tempo_v3_data.tar.gz
 

--- a/contrib/get_tempo_data.sh
+++ b/contrib/get_tempo_data.sh
@@ -3,7 +3,7 @@
 # Function to display help message
 print_help() {
     echo "get_tempo_data.sh: contrib/get_tempo_data.sh [-v,--verbose]"
-    echo "    Script for downloading/extracting the TEMPO lookup tables."
+    echo "    Script for downloading/extracting the TEMPO v3 lookup tables."
     echo ""
     echo "Options:"
     echo "    -v, --verbose    Turn on wget verbose output."
@@ -46,20 +46,13 @@ BASEDIR=$MYDIR/..
 # Change to directory containing the physics input data, download and extract archive
 mkdir -p $BASEDIR/scm/data/physics_input_data/
 cd $BASEDIR/scm/data/physics_input_data/
-wget ${verbose} https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/tempo_data.tar.gz
-tar -xvzf tempo_data.tar.gz
-rm -f tempo_data.tar.gz
+wget ${verbose} https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/tempo_v3_data.tar.gz
+tar -xvzf tempo_v3_data.tar.gz
+rm -f tempo_v3_data.tar.gz
 
-# The archive uses legacy MP_TEMPO_*.dat names; tempo_v3's Fortran source
-# (module_mp_tempo_cfgs.F90) hardcodes different filenames with no
-# host/namelist override, so symlink to what it actually looks for.
-#
 # qr_acr_qg_data_tempo_v3 -> HAILAWARE variant: workaround for an upstream
 # bug (see claude_bug_report.md) where initialize_arrays_qr_acr_qg() always
 # allocates the hail-aware-sized (nrhg=9) table regardless of hailaware_flag.
-ln -sf MP_TEMPO_HAILAWARE_QRacrQG.dat qr_acr_qg_data_tempo_v3
-ln -sf MP_TEMPO_QRacrQS.dat           qr_acr_qs_data_tempo_v3
-ln -sf MP_TEMPO_freezeH2O.dat         freeze_water_data_tempo_v3
 
 # ccn_activate.bin isn't in the downloaded archive at all -- it's small
 # (~35KB) and checked directly into the TEMPO submodule, so symlink it in

--- a/contrib/get_thompson_tables.sh
+++ b/contrib/get_thompson_tables.sh
@@ -10,7 +10,7 @@ print_help() {
     echo "    --help           Show this help message and exit."
 }
 
-verbose="-q"
+verbose="-v"
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in

--- a/contrib/get_thompson_tables.sh
+++ b/contrib/get_thompson_tables.sh
@@ -11,6 +11,12 @@ print_help() {
 }
 
 verbose="-v"
+wget_options=(
+    --tries=10
+    --waitretry=10
+    --retry-connrefused
+    --retry-on-http-error=429,500,502,503,504
+)
 # Parse command-line arguments
 while [[ "$#" -gt 0 ]]; do
     case $1 in
@@ -45,7 +51,7 @@ BASEDIR=$MYDIR/..
 
 # Change to directory containing the physics input data, download and extract archive
 cd $BASEDIR/scm/data/physics_input_data/
-wget ${verbose} https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/thompson_tables.tar.gz
+wget ${verbose} "${wget_options[@]}" https://github.com/NCAR/ccpp-scm/releases/download/v7.0.0/thompson_tables.tar.gz
 tar -xvf thompson_tables.tar.gz
 rm -f thompson_tables.tar.gz
 cd $BASEDIR/

--- a/scm/src/CCPP_typedefs.F90
+++ b/scm/src/CCPP_typedefs.F90
@@ -1158,12 +1158,15 @@ contains
 
     if (Model%imp_physics == Model%imp_physics_thompson .or. &
          Model%imp_physics == Model%imp_physics_tempo) then
+       Interstitial%nvdiff = 9
+
       if (Model%ltaerosol) then
-        Interstitial%nvdiff = 12
-     else if (Model%mraerosol) then
-        Interstitial%nvdiff = 10
-      else
-        Interstitial%nvdiff = 9
+        Interstitial%nvdiff = Interstitial%nvdiff + 3
+      else if (Model%mraerosol .and. Model%imp_physics /= Model%imp_physics_tempo) then
+        Interstitial%nvdiff = Interstitial%nvdiff + 1
+      endif
+      if (Model%imp_physics == Model%imp_physics_tempo .and. Model%lthailaware) then
+        Interstitial%nvdiff = Interstitial%nvdiff + 2
       endif
       if (Model%satmedmf) Interstitial%nvdiff = Interstitial%nvdiff + 1
     elseif ( Model%imp_physics == Model%imp_physics_nssl ) then
@@ -1247,12 +1250,14 @@ contains
         Interstitial%nvdiff = 7
      elseif (Model%imp_physics == Model%imp_physics_thompson .or. &
           Model%imp_physics == Model%imp_physics_tempo) then
+        Interstitial%nvdiff = 9
         if (Model%ltaerosol) then
-          Interstitial%nvdiff = 12
-        else if (Model%mraerosol) then
-          Interstitial%nvdiff = 10
-        else
-          Interstitial%nvdiff = 9
+           Interstitial%nvdiff = Interstitial%nvdiff + 3
+        else if (Model%mraerosol .and. Model%imp_physics /= Model%imp_physics_tempo) then
+           Interstitial%nvdiff = Interstitial%nvdiff + 1
+        endif
+        if (Model%imp_physics == Model%imp_physics_tempo .and. Model%lthailaware) then
+           Interstitial%nvdiff = Interstitial%nvdiff + 2
         endif
       else
         error stop "Selected microphysics scheme is not supported when coupling with chemistry"

--- a/scm/src/GFS_typedefs.F90
+++ b/scm/src/GFS_typedefs.F90
@@ -5,7 +5,7 @@ module GFS_typedefs
 
    use module_radsw_parameters,  only: topfsw_type, sfcfsw_type, NBDSW
    use module_radlw_parameters,  only: topflw_type, sfcflw_type, NBDLW
-   use module_mp_tempo_params,   only: ty_tempo_cfg
+   use module_mp_tempo_cfgs,     only: ty_tempo_cfgs
    use module_ozphys,            only: ty_ozphys
    use module_h2ophys,           only: ty_h2ophys
    use module_ccpp_suite_simulator, only: base_physics_process
@@ -971,6 +971,10 @@ module GFS_typedefs
     logical              :: top_at_1                !< Vertical ordering flag.
     integer              :: iSFC                    !< Vertical index for surface
     integer              :: iTOA                    !< Vertical index for TOA
+    logical              :: is_init_lw_gas_optics   = .false.  !< flag to denote whether LW radiation gas optics have been initialized
+    logical              :: is_init_sw_gas_optics   = .false.  !< flag to denote whether SW radiation gas optics have been initialized
+    logical              :: is_init_lw_cloud_optics = .false.  !< flag to denote whether LW radiation cloud optics have been initialized
+    logical              :: is_init_sw_cloud_optics = .false.  !< flag to denote whether SW radiation cloud optics have been initialized
 
 !--- microphysical switch
     logical              :: convert_dry_rho = .true.       !< flag for converting mass/number concentrations from moist to dry
@@ -1076,8 +1080,9 @@ module GFS_typedefs
     real(kind=kind_phys) :: dt_inner        !< time step for the inner loop in s
     logical              :: sedi_semi       !< flag for semi Lagrangian sedi of rain
     integer              :: decfl           !< deformed CFL factor
-    type(ty_tempo_cfg)   :: tempo_cfg       !< Thompson MP configuration information.
+    type(ty_tempo_cfgs)  :: tempo_cfgs      !< Tempo MP configuration information.
     logical              :: thompson_mp_is_init=.false. !< Local scheme initialization flag
+    logical              :: tempo_mp_is_init=.false. !< Local scheme initialization flag
     real(kind=kind_phys) :: nt_c_l          !< prescribed cloud liquid water number concentration over land
     real(kind=kind_phys) :: nt_c_o          !< prescribed cloud liquid water number concentration over ocean
     real(kind=kind_phys) :: av_i            !< transition value of coefficient matching at crossover from cloud ice to snow
@@ -3385,9 +3390,17 @@ module GFS_typedefs
     endif
 
     !--- needed for Thompson's aerosol option
-    if((Model%imp_physics == Model%imp_physics_thompson .or. &
-         Model%imp_physics == Model%imp_physics_tempo) .and. &
+    if((Model%imp_physics == Model%imp_physics_thompson) .and. &
          (Model%ltaerosol .or. Model%mraerosol)) then
+      allocate (Coupling%nwfa2d (IM))
+      allocate (Coupling%nifa2d (IM))
+      Coupling%nwfa2d   = clear_val
+      Coupling%nifa2d   = clear_val
+    endif
+
+    !--- needed for Tempo's aerosol option
+    if((Model%imp_physics == Model%imp_physics_tempo) .and. &
+         (Model%ltaerosol)) then
       allocate (Coupling%nwfa2d (IM))
       allocate (Coupling%nifa2d (IM))
       Coupling%nwfa2d   = clear_val
@@ -5112,12 +5125,8 @@ module GFS_typedefs
 
 !--- TEMPO MP parameters
     ! DJS to Anders: Maybe we put more of these nml options into the TEMPO configuration type?
-    Model%tempo_cfg%aerosol_aware = (ltaerosol .or. mraerosol)
-    Model%tempo_cfg%hail_aware    = lthailaware
-    if (Model%ltaerosol .and. Model%mraerosol) then
-       write(0,*) 'Logic error: Only one TEMPO aerosol option can be true, either ltaerosol or mraerosol)'
-       stop
-    end if
+    Model%tempo_cfgs%aerosolaware_flag = ltaerosol
+    Model%tempo_cfgs%hailaware_flag    = lthailaware
 
 !--- F-A MP parameters
     Model%rhgrd            = rhgrd

--- a/scm/src/GFS_typedefs.F90
+++ b/scm/src/GFS_typedefs.F90
@@ -1080,6 +1080,7 @@ module GFS_typedefs
     real(kind=kind_phys) :: dt_inner        !< time step for the inner loop in s
     logical              :: sedi_semi       !< flag for semi Lagrangian sedi of rain
     integer              :: decfl           !< deformed CFL factor
+    logical              :: do_sat_adj      !< flag for saturation adjustment for microphysics in dynamics
     type(ty_tempo_cfgs)  :: tempo_cfgs      !< Tempo MP configuration information.
     logical              :: thompson_mp_is_init=.false. !< Local scheme initialization flag
     logical              :: tempo_mp_is_init=.false. !< Local scheme initialization flag
@@ -3768,6 +3769,7 @@ module GFS_typedefs
     real(kind=kind_phys) :: dt_inner       = -999.0             !< time step for the inner loop
     logical              :: sedi_semi      = .false.            !< flag for semi Lagrangian sedi of rain
     integer              :: decfl          = 8                  !< deformed CFL factor
+    logical              :: do_sat_adj     = .false.            !< flag for saturation adjustment for microphysics in dynamics
     real(kind=kind_phys) :: nt_c_l         = 150.e6             !< prescribed cloud liquid water number concentration over land
     real(kind=kind_phys) :: nt_c_o         = 50.e6              !< prescribed cloud liquid water number concentration over ocean
     real(kind=kind_phys) :: av_i           = -999.0             !< transition value of coefficient matching at crossover from cloud ice to snow
@@ -4315,7 +4317,7 @@ module GFS_typedefs
                                ttendlim, ext_diag_thompson, nt_c_l, nt_c_o, av_i, xnc_max,  &
                                ssati_min, Nt_i_max, rr_min, fs_fac_rain, fs_fac_snow,       &
                                dt_inner, lgfdlmprad,                                        &
-                               sedi_semi, decfl,                                            &
+                               sedi_semi, decfl, do_sat_adj,                                &
                                nssl_cccn, nssl_alphah, nssl_alphahl,                        &
                                nssl_alphar, nssl_ehw0, nssl_ehlw0,                          &
                                nssl_invertccn, nssl_hail_on, nssl_ccn_on, nssl_3moment,     &
@@ -5113,6 +5115,7 @@ module GFS_typedefs
     endif
     Model%sedi_semi        = sedi_semi
     Model%decfl            = decfl
+    Model%do_sat_adj       = do_sat_adj
     Model%nt_c_l           = nt_c_l
     Model%nt_c_o           = nt_c_o
     Model%av_i             = av_i
@@ -6577,6 +6580,7 @@ module GFS_typedefs
                                           ' dt_inner =',Model%dt_inner, &
                                           ' sedi_semi=',Model%sedi_semi, &
                                           ' decfl=',decfl, &
+                                          ' do_sat_adj=',Model%do_sat_adj, &
                                           ' nt_c_l=',nt_c_l, &
                                           ' nt_c_o=',nt_c_o, &
                                           ' av_i=',av_i, &
@@ -7172,6 +7176,7 @@ module GFS_typedefs
         print *, ' dt_inner          : ', Model%dt_inner
         print *, ' sedi_semi         : ', Model%sedi_semi
         print *, ' decfl             : ', Model%decfl
+        print *, ' do_sat_adj        : ', Model%do_sat_adj
         print *, ' nt_c_l            : ', Model%nt_c_l
         print *, ' nt_c_o            : ', Model%nt_c_o
         print *, ' av_i              : ', Model%av_i

--- a/scm/src/GFS_typedefs.F90
+++ b/scm/src/GFS_typedefs.F90
@@ -3769,7 +3769,6 @@ module GFS_typedefs
     real(kind=kind_phys) :: dt_inner       = -999.0             !< time step for the inner loop
     logical              :: sedi_semi      = .false.            !< flag for semi Lagrangian sedi of rain
     integer              :: decfl          = 8                  !< deformed CFL factor
-    logical              :: do_sat_adj     = .false.            !< flag for saturation adjustment for microphysics in dynamics
     real(kind=kind_phys) :: nt_c_l         = 150.e6             !< prescribed cloud liquid water number concentration over land
     real(kind=kind_phys) :: nt_c_o         = 50.e6              !< prescribed cloud liquid water number concentration over ocean
     real(kind=kind_phys) :: av_i           = -999.0             !< transition value of coefficient matching at crossover from cloud ice to snow
@@ -4317,7 +4316,7 @@ module GFS_typedefs
                                ttendlim, ext_diag_thompson, nt_c_l, nt_c_o, av_i, xnc_max,  &
                                ssati_min, Nt_i_max, rr_min, fs_fac_rain, fs_fac_snow,       &
                                dt_inner, lgfdlmprad,                                        &
-                               sedi_semi, decfl, do_sat_adj,                                &
+                               sedi_semi, decfl,                                            &
                                nssl_cccn, nssl_alphah, nssl_alphahl,                        &
                                nssl_alphar, nssl_ehw0, nssl_ehlw0,                          &
                                nssl_invertccn, nssl_hail_on, nssl_ccn_on, nssl_3moment,     &
@@ -5115,7 +5114,8 @@ module GFS_typedefs
     endif
     Model%sedi_semi        = sedi_semi
     Model%decfl            = decfl
-    Model%do_sat_adj       = do_sat_adj
+    ! TEMPO expects do_sat_adj variable to exist, but SCM never calls so set to .false.
+    Model%do_sat_adj       = .false. 
     Model%nt_c_l           = nt_c_l
     Model%nt_c_o           = nt_c_o
     Model%av_i             = av_i
@@ -6580,7 +6580,6 @@ module GFS_typedefs
                                           ' dt_inner =',Model%dt_inner, &
                                           ' sedi_semi=',Model%sedi_semi, &
                                           ' decfl=',decfl, &
-                                          ' do_sat_adj=',Model%do_sat_adj, &
                                           ' nt_c_l=',nt_c_l, &
                                           ' nt_c_o=',nt_c_o, &
                                           ' av_i=',av_i, &
@@ -7176,7 +7175,6 @@ module GFS_typedefs
         print *, ' dt_inner          : ', Model%dt_inner
         print *, ' sedi_semi         : ', Model%sedi_semi
         print *, ' decfl             : ', Model%decfl
-        print *, ' do_sat_adj        : ', Model%do_sat_adj
         print *, ' nt_c_l            : ', Model%nt_c_l
         print *, ' nt_c_o            : ', Model%nt_c_o
         print *, ' av_i              : ', Model%av_i

--- a/scm/src/GFS_typedefs.meta
+++ b/scm/src/GFS_typedefs.meta
@@ -602,6 +602,7 @@
   dimensions = (horizontal_dimension,vertical_layer_dimension)
   type = real
   kind = kind_phys
+  active = (index_of_mass_number_concentration_of_graupel_in_tracer_concentration_array > 0)
 [gq0(:,:,index_of_mass_number_concentration_of_hail_in_tracer_concentration_array)]
   standard_name = mass_number_concentration_of_hail
   long_name = number concentration of hail
@@ -4592,6 +4593,30 @@
   units = flag
   dimensions = ()
   type = integer
+[is_init_sw_gas_optics]
+  standard_name = flag_for_rrmtgp_sw_gas_optics_initialization
+  long_name = flag carrying scheme initialization status
+  units = flag
+  dimensions = ()
+  type = logical
+[is_init_sw_cloud_optics]
+  standard_name = flag_for_rrmtgp_sw_cloud_optics_initialization
+  long_name = flag carrying scheme initialization status
+  units = flag
+  dimensions = ()
+  type = logical
+[is_init_lw_gas_optics]
+  standard_name = flag_for_rrmtgp_lw_gas_optics_initialization
+  long_name = flag carrying scheme initialization status
+  units = flag
+  dimensions = ()
+  type = logical
+[is_init_lw_cloud_optics]
+  standard_name = flag_for_rrmtgp_lw_cloud_optics_initialization
+  long_name = flag carrying scheme initialization status
+  units = flag
+  dimensions = ()
+  type = logical
 [convert_dry_rho]
   standard_name = flag_for_converting_hydrometeors_from_moist_to_dry_air
   long_name = flag for converting hydrometeors from moist to dry air
@@ -5202,14 +5227,20 @@
   units = count
   dimensions = ()
   type = integer
-[tempo_cfg]
+[tempo_cfgs]
   standard_name = configuration_for_TEMPO_microphysics
   long_name = configuration information for TEMPO microphysics
   units = mixed
   dimensions = ()
-  type = ty_tempo_cfg
+  type = ty_tempo_cfgs
 [thompson_mp_is_init]
   standard_name = flag_for_thompson_mp_scheme_initialization
+  long_name = flag carrying scheme initialization status
+  units = flag
+  dimensions = ()
+  type = logical
+[tempo_mp_is_init]
+  standard_name = flag_for_tempo_mp_scheme_initialization
   long_name = flag carrying scheme initialization status
   units = flag
   dimensions = ()
@@ -10796,7 +10827,6 @@
   dependencies_path = ../../ccpp/physics/physics
   dependencies = hooks/machine.F,hooks/physcons.F90
   dependencies = Radiation/RRTMG/radlw_param.f,Radiation/RRTMG/radsw_param.f
-  dependencies = MP/TEMPO/TEMPO/module_mp_tempo_params.F90
   dependencies = photochem/module_ozphys.F90,photochem/module_h2ophys.F90
   dependencies = SFC_Models/Land/Noahmp/lnd_iau_mod.F90
   dependencies = Interstitials/UFS_SCM_NEPTUNE/GFS_ccpp_suite_sim_pre.F90

--- a/scm/src/GFS_typedefs.meta
+++ b/scm/src/GFS_typedefs.meta
@@ -5227,6 +5227,12 @@
   units = count
   dimensions = ()
   type = integer
+[do_sat_adj]
+  standard_name = flag_for_saturation_adjustment_for_microphysics_in_dynamics
+  long_name = flag for saturation adjustment for microphysics in dynamics
+  units = none
+  dimensions = ()
+  type = logical
 [tempo_cfgs]
   standard_name = configuration_for_TEMPO_microphysics
   long_name = configuration information for TEMPO microphysics


### PR DESCRIPTION
This PR catches the NCAR:main branch up with changes from the ufs-community:ufs/dev branch.

Associated ufs/dev PR:
- ufs-community/ccpp-physics#353
- ufs-community/ccpp-physics#369 
  - this had `is_init_sw_gas_optics, is_init_lw_gas_optics, is_init_sw_cloud_optics, is_init_lw_cloud_optics` additions that needed to be brought over to SCM

Associated ufsatm PR:
- NOAA-EMC/ufsatm#1063

Associated ufs-weather-model PR:
- ufs-community/ufs-weather-model#3078

Associated NCAR PR:
 - NCAR/ccpp-physics#1231

Additional Changes:
 - This [commit](https://github.com/NCAR/ccpp-scm/pull/711/changes/fb0b8775fb194eb383a3689e1f61d7937d2e7c83) fixes some bugs in the data-retrieval scripts

