### PR TITLE
Add CMake Source Directory Guard and Spack Stack 2.1.1 Module Files

### DIFF
--- a/scm/etc/modules/derecho_gnu/.modulerc.lua
+++ b/scm/etc/modules/derecho_gnu/.modulerc.lua
@@ -1,1 +1,1 @@
-module_version("derecho_gnu/2.1.0", "default")
+module_version("derecho_gnu/2.1.1", "default")

--- a/scm/etc/modules/derecho_gnu/2.1.1.lua
+++ b/scm/etc/modules/derecho_gnu/2.1.1.lua
@@ -6,10 +6,9 @@ the CISL machine Derecho (Cray) using GNU 13.3.1
 whatis([===[Loads spack-stack libraries needed for building the CCPP SCM on Derecho with GNU compilers]===])
 
 
-local spack_root = "/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-2.1.0/envs/ue-gcc-13.3.1/"
+local spack_root = "/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-2.1.1/envs/ue-gcc-13.3.1/"
 prepend_path("MODULEPATH", pathJoin(spack_root, "modules/Core/"))
 append_path("MODULEPATH", "/glade/u/apps/derecho/modules/25.10/Core")
-prepend_path("LD_LIBRARY_PATH", pathJoin(spack_root, "install/gcc/13.3.1/openssl-3.4.1-a3zr655/lib64"))
 
 load("stack-gcc/13.3.1")
 load("stack-cray-mpich/8.1.32")

--- a/scm/etc/modules/derecho_intel/2.1.1.lua
+++ b/scm/etc/modules/derecho_intel/2.1.1.lua
@@ -1,0 +1,38 @@
+help([[
+This module loads libraries for building the CCPP Single-Column Model on
+the CISL machine Derecho (Cray) using Intel oneAPI 2025.3.1
+]])
+
+whatis([===[Loads spack-stack libraries needed for building the CCPP SCM on Derecho with Intel compilers]===])
+
+local spack_root = "/glade/work/epicufsrt/contrib/spack-stack/derecho/spack-stack-2.1.1/envs/ue-oneapi-2025.3.1"
+prepend_path("MODULEPATH", pathJoin(spack_root, "modules/Core/"))
+-- External compiler and Cray modules required by the stack's site/setup.sh.
+prepend_path("MODULEPATH", "/opt/cray/pe/modulefiles")
+prepend_path("MODULEPATH", "/glade/work/epicufsrt/contrib/spack-stack/derecho/installs/oneapi-2025.3.1/modulefiles")
+-- Expose libfabric/1.22.0 while retaining the stack's required crayenv.
+append_path("MODULEPATH", "/glade/u/apps/derecho/modules/25.10/Core")
+
+
+load("stack-intel-oneapi-compilers/2025.3.1")
+load("stack-cray-mpich/8.1.32")
+load("python/3.11.11")
+load("cmake/3.31.8")
+
+load("hdf5/1.14.5")
+load("netcdf-c/4.9.2")
+load("netcdf-fortran/4.6.1")
+load("bacio/2.6.0")
+load("ip/5.4.0")
+load("w3emc/2.13.0")
+
+load("py-f90nml/1.4.3")
+load("py-netcdf4/1.7.2")
+
+-- emacs not in intel spack stack 2.1.1
+prepend_path("PATH", "/glade/u/apps/derecho/25.10/spack/opt/spack/emacs/30.2/gcc/12.5.0/azrq/bin")
+
+setenv("CMAKE_C_COMPILER","cc")
+setenv("CMAKE_CXX_COMPILER","CC")
+setenv("CMAKE_Fortran_COMPILER","ftn")
+setenv("CMAKE_Platform","derecho.intel")

--- a/scm/etc/modules/ursa_gnu/2.1.1.lua
+++ b/scm/etc/modules/ursa_gnu/2.1.1.lua
@@ -1,0 +1,31 @@
+help([[
+This module loads libraries for building the CCPP Single-Column Model on
+the NOAA RDHPC machine Ursa using GNU 12.4
+]])
+
+whatis([===[Loads spack-stack libraries needed for building the CCPP SCM on Ursa with Intel compilers ]===])
+
+prepend_path("MODULEPATH","/contrib/spack-stack/spack-stack-2.1.1/envs/ue-gcc-12.4.0/modules/Core")
+
+load("stack-gcc/12.4.0")
+load("stack-openmpi/4.1.6")
+load("python/3.11.11")
+load("cmake/3.31.8")
+
+load("hdf5/1.14.5")
+load("netcdf-c/4.9.2")
+load("netcdf-fortran/4.6.1")
+load("bacio/2.6.0")
+load("ip/5.4.0")
+load("w3emc/2.13.0")
+load("esmf/8.8.0")
+
+load("py-f90nml")
+load("py-netcdf4/1.7.2")
+
+setenv("CMAKE_C_COMPILER","mpicc")
+setenv("CMAKE_CXX_COMPILER","mpicxx")
+setenv("CMAKE_Fortran_COMPILER","mpif90")
+setenv("CMAKE_Platform","ursa.gnu")
+
+-- execute{cmd="source /scratch3/BMC/gmtb/ccpp-scm-software/spack-stack-2.0.0-gnu/bin/activate", modeA={"load"}}

--- a/scm/etc/modules/ursa_intel/2.1.1.lua
+++ b/scm/etc/modules/ursa_intel/2.1.1.lua
@@ -1,0 +1,31 @@
+help([[
+This module loads libraries for building the CCPP Single-Column Model on
+the NOAA RDHPC machine Ursa using Intel oneAPI 2025.3.1
+]])
+
+whatis([===[Loads spack-stack libraries needed for building the CCPP SCM on Ursa with Intel compilers ]===])
+
+prepend_path("MODULEPATH","/contrib/spack-stack/spack-stack-2.1.1/envs/ue-oneapi-2025.3.1/modules/Core")
+
+load("stack-intel-oneapi-compilers/2025.3.1")
+load("stack-intel-oneapi-mpi/2021.17")
+load("python/3.11.11")
+load("cmake/3.31.8")
+
+load("hdf5/1.14.5")
+load("netcdf-c/4.9.2")
+load("netcdf-fortran/4.6.1")
+load("bacio/2.6.0")
+load("ip/5.4.0")
+load("w3emc/2.13.0")
+load("esmf/8.8.0")
+
+load("py-f90nml")
+load("py-netcdf4/1.7.2")
+
+setenv("CMAKE_C_COMPILER","cc")
+setenv("CMAKE_CXX_COMPILER","CC")
+setenv("CMAKE_Fortran_COMPILER","ftn")
+setenv("CMAKE_Platform","ursa.intel")
+
+-- execute{cmd="source /scratch3/BMC/gmtb/ccpp-scm-software/spack-stack-2.0.0-intel/bin/activate", modeA={"load"}}

--- a/scm/src/CMakeLists.txt
+++ b/scm/src/CMakeLists.txt
@@ -1,7 +1,12 @@
-#
-# CCPP SCM source code
-#
+# SCM source directory check
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  message(FATAL_ERROR
+    "\n"
+    "The top-level CMakeLists.txt has moved from scm/src/ to the root of the repository.\n"
+    "Configure from there instead:  cmake <options> /path/to/repo\n")
+endif()
 
+# CCPP SCM source code
 SET(scm_source_files scm.F90
             scm_input.F90
             #scm_utils.F90


### PR DESCRIPTION
SOURCE: Soren Rasmussen

## DESCRIPTION OF CHANGES
  - CMake source directory has previously been moved from `scm/src/` to the top of the directory. Add error message if user's CMake configure option is pointing to the old directory. This will help users get used to the change
  - Adding 2.1.1 spack stack module for GNU and Intel and updating GNU 2.1.0 to work after the Derecho system update
 
## TESTS CONDUCTED
Built SCM_HRRR_gf suite and ran twpice case for Spack  on Derecho. Ursa builds but remains untested.

| Passing Case | Suite       | Namelist          | Status |
| --- | --- | --- |--- |
| twpice | SCM_HRRR_gf | input_HRRR_gf.nml | 0      |


## NOTE
For the Ursa modules I commented out the following line because the equivalent path does not exist for Spack Stack 2.1.1
``` lmod
-- execute{cmd="source /scratch3/BMC/gmtb/ccpp-scm-software/spack-stack-2.0.0-gnu/bin/activate", modeA={"load"}}
```