### PR TITLE
Updated SCM documentation for v8.0.0 release

### DIFF
--- a/scm/doc/TechGuide/acknow.rst
+++ b/scm/doc/TechGuide/acknow.rst
@@ -7,6 +7,6 @@ acknowledge the Developmental Testbed Center team.
 For referencing this document please use:
 
       Firl, G., D. Swales, L. Carson, L. Bernardet, D. Heinzeller, M. Harrold, T. Hertneky, and
-      M. Kavulich, 2024. Common Community Physics Package Single Column Model v7.0.1 User and
-      Technical Guide. Available at https://ccpp-scm.readthedocs.io/en/v7.0.1/.
+      M. Kavulich, 2026. Common Community Physics Package Single Column Model v8.0.0 User and
+      Technical Guide. Available at https://ccpp-scm.readthedocs.io/en/v8.0.0/.
 

--- a/scm/doc/TechGuide/chap_ccpp.rst
+++ b/scm/doc/TechGuide/chap_ccpp.rst
@@ -4,7 +4,7 @@ CCPP Interface
 ==============
 
 Chapter 6 of the CCPP v7 Technical Documentation
-(https://ccpp-techdoc.readthedocs.io/en/v7.0.0/) provides a wealth of
+(https://ccpp-techdoc.readthedocs.io/en/v8.0.0/) provides a wealth of
 information on the overall process of connecting a host model to the
 CCPP framework for calling physics. This chapter describes the
 particular implementation within this SCM, including how to set up,
@@ -25,7 +25,7 @@ Preparing data from the SCM
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As described in sections 6.1 and 6.2 of the `CCPP Technical
-Documentation <https://ccpp-techdoc.readthedocs.io/en/v7.0.0/>`__ a host
+Documentation <https://ccpp-techdoc.readthedocs.io/en/v8.0.0/>`__ a host
 model must allocate memory and provide metadata for variables that are
 passed into and out of the schemes within the physics suite. As of this
 release, in practice this means that a host model must do this for all
@@ -35,7 +35,7 @@ schemes are allocated and documented in the file ``ccpp-scm/scm/src/scm_type_def
 within the ``physics`` derived data type. This derived data type initializes its
 component variables in a ``create`` type-bound procedure. As mentioned in section
 6.2 of the `CCPP Technical
-Documentation <https://ccpp-techdoc.readthedocs.io/en/v7.0.0/>`__, files
+Documentation <https://ccpp-techdoc.readthedocs.io/en/v8.0.0/>`__, files
 containing all required metadata was constructed for describing all
 variables in the derived data type. These files are ``scm/src/GFS_typedefs.meta,``, ``scm/src/CCPP_typedefs.meta``, and ``scm_physical_constants.meta``. Further, ``scm_type_defs.meta``
 exists to provide metadata for derived data type definitions and their
@@ -49,7 +49,7 @@ Editing and running the Capgen scripts
 
 General instructions for configuring and running the Capgen scripts can be found
 in chapter 8 of the `CCPP Technical
-Documentation <https://ccpp-techdoc.readthedocs.io/en/v7.0.0/>`__. As mentioned in :numref:`Section %s <compiling>`, this script must be run
+Documentation <https://ccpp-techdoc.readthedocs.io/en/v8.0.0/>`__. As mentioned in :numref:`Section %s <compiling>`, this script must be run
 to reconcile data provided by the SCM with data required by the physics
 schemes before compilation – this is done automatically by ``cmake``.
 
@@ -92,7 +92,7 @@ described in sections
 respectively. A more general description of the process for performing
 suite initialization and running can also be found in sections 6.4 and
 6.5 of the `CCPP Technical
-Documentation <https://ccpp-techdoc.readthedocs.io/en/v7.0.0/>`__.
+Documentation <https://ccpp-techdoc.readthedocs.io/en/v8.0.0/>`__.
 
 Changing a suite
 ----------------
@@ -104,7 +104,7 @@ Prior to being able to swap a scheme within a suite, one must first add
 a CCPP-compliant scheme to the pool of available schemes in the CCPP
 physics repository. This process is described in chapter 2 of the `CCPP
 Technical
-Documentation <https://ccpp-techdoc.readthedocs.io/en/v7.0.0/>`__.
+Documentation <https://ccpp-techdoc.readthedocs.io/en/v8.0.0/>`__.
 
 Once a CCPP-compliant scheme has been added to the CCPP physics
 repository, the process for modifying an existing suite should take the
@@ -123,7 +123,7 @@ following steps into account:
    -  Do any of the new variables need to be calculated in an
       interstitial scheme? If so, one must be written and made
       CCPP-compliant itself. The `CCPP Technical
-      Documentation <https://ccpp-techdoc.readthedocs.io/en/v7.0.0/>`__
+      Documentation <https://ccpp-techdoc.readthedocs.io/en/v8.0.0/>`__
       will help in this endeavor, and the process outlined in its
       chapter 2 should be followed.
 
@@ -151,7 +151,7 @@ following steps into account:
    associated interstitial ``<scheme>`` elements and simply replacing the scheme
    names to reflect their replacements. See chapter 4 of the `CCPP
    Technical
-   Documentation <https://ccpp-techdoc.readthedocs.io/en/v7.0.0/>`__ for
+   Documentation <https://ccpp-techdoc.readthedocs.io/en/v8.0.0/>`__ for
    further details.
 
 Modifying “groups” of parameterizations
@@ -230,7 +230,7 @@ would do so:
    cannot be used in a physics scheme yet. For that, you’ll need to add
    an entry in the corresponding metadata file. See section 2.2 of the
    `CCPP Technical
-   Documentation <https://ccpp-techdoc.readthedocs.io/en/v7.0.0/CompliantPhysicsParams.html#metadata-table-rules>`__
+   Documentation <https://ccpp-techdoc.readthedocs.io/en/v8.0.0/CompliantPhysicsParams.html#metadata-table-rules>`__
    for more information regarding the format.
 
 #. On the physics scheme side, there will also be a metadata file entry

--- a/scm/doc/TechGuide/chap_ccpp.rst
+++ b/scm/doc/TechGuide/chap_ccpp.rst
@@ -15,9 +15,11 @@ Setting up a suite
 
 Setting up a physics suite for use in the CCPP SCM with the CCPP
 framework involves three steps: preparing data to be made available to
-physics through the CCPP, running the ``ccpp_prebuild.py`` script to reconcile SCM-provided
+physics through the CCPP, running the Capgen scripts* to reconcile SCM-provided
 variables with physics-required variables, and preparing a suite
-definition file.
+definition file. 
+*The Capgen scripts and their use are described in chapter 8 of the `CCPP Technical
+Documentation <https://ccpp-techdoc.readthedocs.io/en/v8.0.0/>`__.
 
 Preparing data from the SCM
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -42,20 +44,12 @@ the data. The standard names of all variables in this table must match
 with a corresponding variable within one or more of the physics schemes.
 A list of all standard names used can be found in ``ccpp/framework/doc/DevelopersGuide/CCPP_VARIABLES_SCM.pdf``.
 
-Editing and running ``ccpp_prebuild.py``
+Editing and running the Capgen scripts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-General instructions for configuring and running the ``ccpp_prebuild.py`` script can be found
+General instructions for configuring and running the Capgen scripts can be found
 in chapter 8 of the `CCPP Technical
-Documentation <https://ccpp-techdoc.readthedocs.io/en/v7.0.0/>`__. The
-script expects to be run with a host-model-dependent configuration file,
-passed as argument ``–config=path_to_config_file``. Within this configuration file are variables that
-hold paths to the variable definition files (where metadata tables can
-be found on the host model side), the scheme files (a list of paths to
-all source files containing scheme entry points), the auto-generated
-physics schemes makefile snippet, the auto-generated physics scheme caps
-makefile snippet, and the directory where the auto-generated physics
-caps should be written out to. As mentioned in :numref:`Section %s <compiling>`, this script must be run
+Documentation <https://ccpp-techdoc.readthedocs.io/en/v7.0.0/>`__. As mentioned in :numref:`Section %s <compiling>`, this script must be run
 to reconcile data provided by the SCM with data required by the physics
 schemes before compilation – this is done automatically by ``cmake``.
 

--- a/scm/doc/TechGuide/chap_intro.rst
+++ b/scm/doc/TechGuide/chap_intro.rst
@@ -17,7 +17,7 @@ This version contains all parameterizations of NOAA’s evolved
 operational GFS v16 suite (implemented in 2021), plus additional
 developmental schemes. The schemes are grouped in five supported suites
 described in detail in the `CCPP Scientific
-Documentation <https://dtcenter.ucar.edu/GMTB/v7.0.0/sci_doc/>`__
+Documentation <https://dtcenter.ucar.edu/GMTB/v8.0.0/sci_doc/>`__
 (GFS_v16, GFS_v16_RRTMGP, GFS_v17_p8_ugwpv1, HRRR_gf, and WoFS_v0).
 
 This document serves as both the User and Technical Guides for this
@@ -35,51 +35,19 @@ through the CCPP infrastructure.
 Version Notes
 -------------
 
-The CCPP SCM v7.0.1 contains the following minor changes since v7.0.0.
 
--  Enhanced UFS case generation tools: Reinstated functionality to support specifying
-   i, j grid indices (from the FV3 native grid) along with a tile number in
-   UFS_case_gen.py to generate single-column cases. Also added the ability to accept
-   a list of i, j indices for batch generation of multiple cases.
-
--  Use of standardized missing values: Replaced hard coded missing values, -9999.0
-   and -9999, with the _FillValue or missing value attributes defined in the NetCDF
-   variables.
-
--  Fix area logic in the SCM: Corrected assignment of the column area from the DEPHY
-   forcing file by removing the dependency on surface forcing LSM. Also allow the
-   column_area in the configuration namelist to override the DEPHY assignment.
-
--  Enhanced documentation for 1) using the DEPHY converter script, which converts
-   forcing files from the legacy format to the DEPHY v1.0 format, and 2) including
-   expected behavior of the Near-Surface Sea Temperature (NSST) scheme within the SCM.
-
--  Added support for NOAA’s Ursa platform using spack-stack v1.9.1.
-
-The CCPP SCM v7.0.0 contains the following major and minor changes since v6.0.
+The CCPP SCM v8.0.0 contains the following major and minor changes since v7.0.
 
 Major
 
--  Ability to generate SCM cases from UFS simulations using either derived forcings
-   or native forcings from the dynamical core.
+-  Update SCM to use new CCPP framework, capgen-v1
 
--  Support for single precision physics within the SCM.
+-  Updated technical documentation.
 
 Minor
 
--  Addition of new physics schemes; RRTMGP radiation and CLM Lake Model, along with
-   updates to existing schemes.
+   N/A
 
--  CCPP SCM support for the latest operational/research physics configurations used
-   across UFS applications, including the GFS_v17_p8_ugwpv1, GFS_v16_RRTMGP, and
-   HRRR_gf suites.
-
--  New SCM cases; MOSAiC-AMPS, MOSAiC-SS, COMBLE, and a catolog of cases in the
-   `GdR-DEPHY <https://github.com/GdR-DEPHY/DEPHY-SCM>`__ repository that can be run
-   with CCPP SCM.
-
--  Updated `Scientific Documentation <https://dtcenter.ucar.edu/GMTB/v7.0.0/sci_doc/>`__, User's Guide, Technical Documentation, and
-   online tutorials.
 
 Limitations
 ~~~~~~~~~~~

--- a/scm/doc/TechGuide/chap_quick.rst
+++ b/scm/doc/TechGuide/chap_quick.rst
@@ -25,7 +25,7 @@ Clone the source using
 
 .. code:: bash
 
-   $ git clone --recursive -b v7.0.1 https://github.com/NCAR/ccpp-scm
+   $ git clone --recursive -b v8.0.0 https://github.com/NCAR/ccpp-scm
 
 The ``--recursive`` option is required to retrieve the ccpp-physics and ccpp-framework code,
 which are stored in separate repositories and linked to the SCM repository as submodules.
@@ -478,7 +478,7 @@ execute the following scripts:
 If the download step fails, make sure that your system’s firewall does
 not block access to GitHub. If it does, download the files ``comparison_data.tar.gz``,
 ``physics_input_data.tar.gz``, ``processed_case_input.tar.gz``, and ``raw_case_input.tar.gz``
-from the `SCM release page <https://github.com/NCAR/ccpp-scm/releases/tag/v7.0.1>`__ using your browser and manually extract its
+from the `SCM release page <https://github.com/NCAR/ccpp-scm/releases/tag/v8.0.0>`__ using your browser and manually extract its
 contents in the directory ``scm/data``. Similarly, do the same for
 ``thompson_tables.tar.gz`` and ``MG_INCCN_data.tar.gz`` and extract
 to ``scm/data/physics_input_data/``.
@@ -802,7 +802,7 @@ internet search.
 Building the Docker image
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The Dockerfile builds CCPP SCM v7.0.1 from source using the GNU
+The Dockerfile builds CCPP SCM v8.0.0 from source using the GNU
 compiler.
 
 The CCPP SCM has a number of system requirements and necessary libraries
@@ -866,7 +866,7 @@ following from the terminal where Docker is run:
 
 .. code:: bash
 
-   $ docker pull dtcenter/ccpp-scm:v7.0.1
+   $ docker pull dtcenter/ccpp-scm:v8.0.0
 
 To verify that it exists afterward, run
 
@@ -954,7 +954,7 @@ Running the Docker image
    .. note::
      If you are using a prebuilt image from Dockerhub, substitute
      the name of the image that was pulled from Dockerhub in the commands
-     above; i.e. instead of ``ccpp-scm`` above, one would have ``dtcenter/ccpp-scm:v7.0.1``.
+     above; i.e. instead of ``ccpp-scm`` above, one would have ``dtcenter/ccpp-scm:v8.0.0``.
 
 #. To use the SCM interactively, run non-default configurations, create
    plots, or even develop code, issue the following command:

--- a/scm/doc/TechGuide/chap_quick.rst
+++ b/scm/doc/TechGuide/chap_quick.rst
@@ -277,7 +277,7 @@ to modify the provided modulefiles to work with your spack-stack install, otherw
 Python requirements
 """""""""""""""""""""
 
-The SCM build system invokes the ``ccpp_prebuild.py`` script, and so the Python environment must be set up prior to building.
+The SCM build system invokes the ``ccpp_capgen.py`` script, and so the Python environment must be set up prior to building.
 As mentioned earlier, a minimum Python version of 3.10 is required. Additionally, there are a few non-default modules required for the SCM to
 function: ``f90nml`` (`documentation <https://f90nml.readthedocs.io/en/latest/index.html>`__) and
 ``netcdf4`` (`documentation <https://unidata.github.io/netcdf4-python/>`__). Users can test if these are installed using this command in
@@ -314,7 +314,7 @@ user environment as described in :numref:`Section %s <use_preconfigured_platfor
 and :numref:`Section %s <setup_supported_platforms>`.
 
 Following this step, the top level build system will use ``cmake`` to query system
-parameters, execute the CCPP prebuild script to match the physics
+parameters, execute the CCPP capgen scripts to match the physics
 variables (between what the host model – SCM – can provide and what is
 needed by physics schemes in the CCPP for the chosen suites), and build
 the physics caps needed to use them. Finally, ``make`` is used to compile the
@@ -410,23 +410,12 @@ components.
 
          $ cmake [-DCMAKE_BUILD_TYPE ...] ../.. 2>&1 | tee log.cmake
 
-   CMake automatically runs the CCPP prebuild script to match required
+   CMake automatically runs the CCPP capgen scripts to match required
    physics variables with those available from the dycore (SCM) and to
-   generate physics caps and makefile segments. It generates software
-   caps for each physics group defined in the supplied Suite Definition
-   Files (SDFs) and generates a static library that becomes part of the
-   SCM executable.
+   generate physics caps. It generates software caps for each physics 
+   group defined in the supplied Suite Definition Files (SDFs) and 
+   generates a static library that becomes part of the SCM executable.
 
-   If necessary, the CCPP prebuild script can be executed manually from
-   the top level directory (``ccpp-scm``). The basic syntax is
-
-   .. code:: bash
-
-      $ ./ccpp/framework/scripts/ccpp_prebuild.py --config=./ccpp/config/ccpp_prebuild_config.py --suites=SCM_GFS_v16,SCM_RAP[...] --builddir=./scm/bin [--debug]
-
-   where the argument supplied via the ``--suites`` variable is a comma-separated
-   list of suite names that exist in the directory. Note that suite
-   names are the suite definition filenames minus the ``suite_`` prefix and ``.xml`` suffix.
 
 #. Compile. Add ``VERBOSE=1`` to obtain more information on the build process.
 
@@ -552,7 +541,7 @@ If using the main branch, you should run the above command to ensure you have th
 -  ``--suite [-s]``
 
    -  The suite should correspond to the name of a suite in ``../ccpp/suites`` (without the
-      ``.xml`` extension) that was supplied in the ``cmake`` or ``ccpp_prebuild`` step.
+      ``.xml`` extension) that was supplied in the ``cmake`` or ``ccpp_capgen`` step.
 
 -  ``--namelist [-n]``
 

--- a/scm/doc/TechGuide/chap_quick.rst
+++ b/scm/doc/TechGuide/chap_quick.rst
@@ -483,7 +483,7 @@ contents in the directory ``scm/data``. Similarly, do the same for
 ``thompson_tables.tar.gz`` and ``MG_INCCN_data.tar.gz`` and extract
 to ``scm/data/physics_input_data/``.
 
-New with the SCM v7 release, static data is available for running cases with GOCART climatological aerosols (where the value of ``iaer`` in the ``&gfs_physics_nml`` namelist starts with 1; see the `CCPP Scientific Documentation <https://dtcenter.ucar.edu/GMTB/v7.0.0/sci_doc/_c_c_p_psuite_nml_desp.html>`__ for more information); one example of this is with the default namelist settings for the GFS_v17_p8_ugwpv1 scheme. This dataset is very large (~12 GB), so it is recommended only to download it if you will be using it.
+New with the SCM v7 release, static data is available for running cases with GOCART climatological aerosols (where the value of ``iaer`` in the ``&gfs_physics_nml`` namelist starts with 1; see the `CCPP Scientific Documentation <https://dtcenter.ucar.edu/GMTB/v8.0.0/sci_doc/_c_c_p_psuite_nml_desp.html>`__ for more information); one example of this is with the default namelist settings for the GFS_v17_p8_ugwpv1 scheme. This dataset is very large (~12 GB), so it is recommended only to download it if you will be using it.
 
 .. code:: bash
 

--- a/scm/doc/TechGuide/chap_repo.rst
+++ b/scm/doc/TechGuide/chap_repo.rst
@@ -27,7 +27,6 @@ Cubed-Sphere (FV3) dynamical core.
 | ``├── LICENSE``
 | ``├── README.md``
 | ``├── ccpp``
-| ``│   ├── config`` - Contains the CCPP prebuild configuration file
 | ``│   ├── framework`` - Contains CCPP framework submodule. See https://github.com/NCAR/ccpp-framework for contents
 | ``│   ├── physics`` - Contains CCPP physics submodule. See https://github.com/NCAR/ccpp-physics for contents
 | ``│   ├── physics_namelists`` - Contains physics namelist files associated with suites

--- a/scm/doc/TechGuide/index.rst
+++ b/scm/doc/TechGuide/index.rst
@@ -1,4 +1,4 @@
-CCPP Single Column Model (SCM) User and Technical Guide v7.0.1
+CCPP Single Column Model (SCM) User and Technical Guide v8.0.0
 ==============================================================
 
 .. toctree::


### PR DESCRIPTION
See title for description - doc link [here](https://dustinswalesccpp-scm.readthedocs.io/en/feature-capgen-v1/).
@hertneky @grantfirl @mkavulich @scrasmussen @mzhangw @ligiabernardet @lulinxue 
- Once ready, we need to merge the [technical doc PR](https://github.com/NCAR/ccpp-doc/pull/81) and tag it v8.0.0. Then the tech doc links here will work.
- Since there are no scientific changes, we don't **need** to update the links to scientific documentation. So should we point to the v7.0.1 documentation? Or tag the documentation again with v8.0.0? 
